### PR TITLE
Update search path to match gennodejs

### DIFF
--- a/utils/message_utils.js
+++ b/utils/message_utils.js
@@ -28,7 +28,7 @@ const messages = require('./messages.js');
 // chaining works by continuing this path prepending.
 let cmakePath = process.env.CMAKE_PREFIX_PATH;
 let cmakePaths = cmakePath.split(':');
-let jsMsgPath = path.join('share', 'node_js', 'ros');
+let jsMsgPath = path.join('share', 'gennodejs', 'ros');
 
 let messagePackageMap = {};
 let messagePackagePathMap = {};


### PR DESCRIPTION
In https://github.com/RethinkRobotics-opensource/gennodejs/pull/7 we updated the location of the generated messages to make future collisions less likely. This updates `rosnodejs` accordingly.
