### PR TITLE
Unifying API for on-the-fly and gennodejs messages

### DIFF
--- a/example2.js
+++ b/example2.js
@@ -1,77 +1,77 @@
 'use strict';
 
 let rosnodejs = require('./index.js');
-// const std_msgs = rosnodejs.require('std_msgs').msg;
-// const SetBool = rosnodejs.require('std_srvs').srv.SetBool;
 
-rosnodejs.use(['std_msgs/String'],
-              ['std_srvs/SetBool'], function() {
+rosnodejs.initNode('/my_node', {
+  messages: ['std_msgs/String'], 
+  services: ['std_srvs/SetBool']
+}).then((rosNode) => {
 
-  const msg = new (rosnodejs.message('std_msgs/String'))(
-    { data: "howdy" });
+  const std_msgs = rosnodejs.require('std_msgs').msg;
+  const msg = new std_msgs.String();
 
-  rosnodejs.initNode('/my_node')
-    .then((rosNode) => {
+  const SetBool = rosnodejs.require('std_srvs').srv.SetBool;
+  const request = new SetBool.Request();
 
-      // EXP 1) Service Server
-      let service = rosNode.advertiseService('/set_bool','std_srvs/SetBool',
-      (req, resp) => {
-        console.log('Handling request! ' + JSON.stringify(req));
-        resp.success = !req.data;
-        resp.message = 'Inverted!';
-        return true;
-      });
-
-      // EXP 2) Service Client
-      setTimeout(function() {
-        let serviceClient = rosNode.serviceClient('/set_bool','std_srvs/SetBool');
-        rosNode.waitForService(serviceClient.getService(), 2000)
-          .then((available) => {
-            if (available) {
-              const request =
-                new (rosnodejs.serviceRequest('std_srvs/SetBool'))({
-                  data: false });
-              serviceClient.call(request, (resp) => {
-                console.log('Service response ' + JSON.stringify(resp));
-              });
-            } else {
-              console.log('Service not available');
-            }
-          });
-      }, 1000); // wait a second before calling our service
-
-      // EXP 3) Params
-      rosNode.setParam('~junk', {'hi': 2}).then(() => {
-        rosNode.getParam('~junk').then((val) => {
-          console.log('Got Param!!! ' + JSON.stringify(val));
-        });
-      });
-
-      // // EXP 4) Publisher
-      let pub = rosNode.advertise('/my_topic','std_msgs/String', {
-        queueSize: 1,
-        latching: true,
-        throttleMs: 9
-      });
-
-      let msgStart = 'my message ';
-      let iter = 0;
-      setInterval(() => {
-        msg.data = msgStart + iter
-        pub.publish(msg);
-        ++iter;
-        if (iter > 200) {
-          iter = 0;
-        }
-      }, 5);
-
-      // EXP 5) Subscriber
-      let sub = rosNode.subscribe('/my_topic', 'std_msgs/String',
-        (data) => {
-          console.log('SUB DATA ', data, data.data);
-        },
-        {queueSize: 1,
-         throttleMs: 1000});
+  // EXP 1) Service Server
+  let service = rosNode.advertiseService(
+    '/set_bool','std_srvs/SetBool',
+    (req, resp) => {
+      console.log('Handling request! ' + JSON.stringify(req));
+      resp.success = !req.data;
+      resp.message = 'Inverted!';
+      return true;
     });
 
+  // EXP 2) Service Client
+  setTimeout(function() {
+    let serviceClient = rosNode.serviceClient('/set_bool','std_srvs/SetBool');
+    rosNode.waitForService(serviceClient.getService(), 2000)
+      .then((available) => {
+        if (available) {
+          const request = new SetBool.Request();
+          request.data = true;
+          serviceClient.call(request, (resp) => {
+            console.log('Service response ' + JSON.stringify(resp));
+          });
+        } else {
+          console.log('Service not available');
+        }
+      });
+  }, 1000); // wait a second before calling our service
+
+  // EXP 3) Params
+  rosNode.setParam('~junk', {'hi': 2}).then(() => {
+    rosNode.getParam('~junk').then((val) => {
+      console.log('Got Param!!! ' + JSON.stringify(val));
+    });
+  });
+
+  // // EXP 4) Publisher
+  let pub = rosNode.advertise('/my_topic','std_msgs/String', {
+    queueSize: 1,
+    latching: true,
+    throttleMs: 9
+  });
+
+  // EXP 5) Subscriber
+  let sub = rosNode.subscribe(
+    '/my_topic', 
+    'std_msgs/String',
+    (data) => {
+      console.log('SUB DATA ', data, data.data);
+    },
+    {queueSize: 1,
+     throttleMs: 1000});
+  
+  let msgStart = 'my message ';
+  let iter = 0;
+  setInterval(() => {
+    msg.data = msgStart + iter
+    pub.publish(msg);
+    ++iter;
+    if (iter > 200) {
+      iter = 0;
+    }
+  }, 5);
 });

--- a/utils/message_utils.js
+++ b/utils/message_utils.js
@@ -207,10 +207,8 @@ let MessageUtils = {
       let type = parts[1];
       return messagePackage.msg[type];
     } else {
-      // console.log("get message from registry");
-      let type = messages.getFromRegistry(rosDataType, "message");
+      let type = messages.getFromRegistry(rosDataType, ["msg"]);
       if (type) {
-        // console.log("got message from registry", type);
         return new type();
       } else {
         console.error('Unable to find message package ' + msgPackage);
@@ -227,18 +225,18 @@ let MessageUtils = {
       let type = parts[1];
       return messagePackage.srv[type];
     } else {
-      // console.log("get service %s from registry", rosDataType);
-      let request = messages.getFromRegistry(rosDataType, "request");
-      let response = messages.getFromRegistry(rosDataType, "response");
+      let request = 
+        messages.getFromRegistry(rosDataType, ["srv", "Request"]);
+      let response = 
+        messages.getFromRegistry(rosDataType, ["srv", "Response"]);
       if (request && response) {
-        return {
-          // Request: new request(),
-          // Response: new response()
+        return { 
           Request: request,
           Response: response
         };
       } else {
-        console.error('Unable to find service package %s: %j %j', msgPackage, request, response);
+        console.error('Unable to find service package %s: %j %j', 
+                      msgPackage, request, response);
         throw new Error();
       }
     }


### PR DESCRIPTION
- returning promise from 'use'
- moved call to use into initNode

Unified APIs: rosnodejs.message now replaced with reosnodejs.require

Addresses part of #14.
- the way require now works is by first checking the registry of
  on-the-fly generated messages. If it finds the class there, it uses
  it, otherwise it will check the filesystem for the pre-compiled
  classes generated by gennodejs
