### PR TITLE
Provide option to anonymize node

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ let Rosnodejs = {
     options = options || {};
     if (options.anonymous) {
       nodeName = _anonymizeNodeName(nodeName);
-      console.log('anonymous node name ' + nodeName);
     }
 
     nodeName = _validateNodeName(nodeName);

--- a/utils/message_utils.js
+++ b/utils/message_utils.js
@@ -184,7 +184,7 @@ let MessageUtils = {
   loadMessagePackage(msgPackage) {
     const indexPath = messagePackagePathMap[msgPackage];
     if (indexPath === undefined) {
-      throw new Error('Unable to find message package %s', msgPackage);
+      throw new Error('Unable to find message package ' + msgPackage);
     }
     try {
       messagePackageMap[msgPackage] = require(indexPath);
@@ -225,17 +225,17 @@ let MessageUtils = {
       let type = parts[1];
       return messagePackage.srv[type];
     } else {
-      let request = 
+      let request =
         messages.getFromRegistry(rosDataType, ["srv", "Request"]);
-      let response = 
+      let response =
         messages.getFromRegistry(rosDataType, ["srv", "Response"]);
       if (request && response) {
-        return { 
+        return {
           Request: request,
           Response: response
         };
       } else {
-        console.error('Unable to find service package %s: %j %j', 
+        console.error('Unable to find service package %s: %j %j',
                       msgPackage, request, response);
         throw new Error();
       }


### PR DESCRIPTION
- Adds support for `anonymous` option when calling `initNode` to anonymize your node name. Follows rospy logic.
- Fixes error message when unable to find message package.
- Also some unintended whitespace changes? Maybe from Atom?

e.g.

```
rospy.initNode('/my_node', {anonymous: true})
.then((nh) => {
   console.log( nh.getNodeName() ); // "/my_node_25878_1464120320242"
});
```
