### PR TITLE
Fix log.debug fails when waiting for ROS Master #13

### DIFF
--- a/utils/xmlrpc_utils.js
+++ b/utils/xmlrpc_utils.js
@@ -19,7 +19,7 @@ module.exports = {
           }
           log.debug('Trying again in ' + timeout +  'ms');
           log.debug('Connection refused during method %s: %j', method, data);
-          this.call(method, data, resolve, reject, timeout);
+          this.call(client, method, data, resolve, reject, log, timeout);
         }
         else if (err || resp[0] !== 1) {
           log.debug('Some other error during %s: %s, %j', method, err, resp);


### PR DESCRIPTION
Fixes #13.
- TODO: currently there is no timeout when failing to connect
