### PR TITLE
The md5sums for service client and server were swapped

### DIFF
--- a/lib/ServiceClient.js
+++ b/lib/ServiceClient.js
@@ -98,7 +98,7 @@ class ServiceClient extends EventEmitter {
     client.connect(serviceInfo, () => {
       this._log.debug('Sending connection header');
       let serviceClientHeader = TcprosUtils.createServiceClientHeader(this._nodeHandle.getNodeName(),
-        this.getService(), this._messageHandler.Response.md5sum(), this.getType());
+        this.getService(), this._messageHandler.Request.md5sum(), this.getType());
       client.write(serviceClientHeader);
     });
 

--- a/lib/ServiceServer.js
+++ b/lib/ServiceServer.js
@@ -77,7 +77,8 @@ class ServiceServer extends EventEmitter {
       // TODO: verify header data
       this._log.debug('Service header ' + JSON.stringify(header));
 
-      let respHeader = TcprosUtils.createServiceServerHeader(this._nodeHandle.getNodeName(), this._messageHandler.Request.md5sum(), this.getType());
+      let respHeader = TcprosUtils.createServiceServerHeader(this._nodeHandle.getNodeName(), this._messageHandler.Response.md5sum(), this.getType());
+
       client.write(respHeader);
       client.$initialized = true;
     }


### PR DESCRIPTION
When trying to call services from turtlesim, I got this error:

```
[ERROR] [1465782638.813189334]: client wants service /turtle1/teleport_relative to have md5sum d41d8cd98f00b204e9800998ecf8427e, but it has 9d5c2dcd348ac8f76ce2a4307bd63a13. Dropping connection.
```

The wrong md5sum being sent was the one from the response handler. I
double checked that the handler classes themselves were correct (and
they were), but then found that the serviceClient itself sends the
md5sum and picked the respectively wrong one (response md5 on request,
and vice versa).

This commit fixes that.
