### PR TITLE
Unify interface further

### DIFF
--- a/example_turtle.js
+++ b/example_turtle.js
@@ -7,8 +7,6 @@
 'use strict';
 
 let rosnodejs = require('./index.js');
-const ActionClient = require('./lib/ActionClient.js');
-
 rosnodejs.initNode('/my_node', {onTheFly: true}).then((rosNode) => {
 
   // get list of existing publishers, subscribers, and services
@@ -77,7 +75,7 @@ rosnodejs.initNode('/my_node', {onTheFly: true}).then((rosNode) => {
   // wait two seconds for previous example to complete
   setTimeout(function() {
       let shapeActionGoal = rosnodejs.require('turtle_actionlib').msg.ShapeActionGoal;
-      let ac = new ActionClient({
+      let ac = rosnodejs.getActionClient({
           type: "turtle_actionlib/ShapeAction",
           actionServer: "/turtle_shape"
         });
@@ -87,6 +85,9 @@ rosnodejs.initNode('/my_node', {onTheFly: true}).then((rosNode) => {
               radius: 1
             }
           }));
+      setTimeout(function() {
+          ac.cancel();
+      }, 1000);
     }, 2000);
 
   // ---------------------------------------------------------

--- a/example_turtle.js
+++ b/example_turtle.js
@@ -1,4 +1,4 @@
-/** 
+/**
     An example of using rosnodejs with turtlesim, incl. services,
     pub/sub, and actionlib. This example uses the on-demand generated
     messages.
@@ -9,16 +9,7 @@
 let rosnodejs = require('./index.js');
 const ActionClient = require('./lib/ActionClient.js');
 
-rosnodejs.initNode('/my_node', {
-  messages: [
-    'turtlesim/Pose',
-    'turtle_actionlib/ShapeActionGoal',
-    'turtle_actionlib/ShapeActionFeedback',
-    'turtle_actionlib/ShapeActionResult',
-    'geometry_msgs/Twist',
-  ],
-  services: ["turtlesim/TeleportRelative"]
-}).then((rosNode) => {
+rosnodejs.initNode('/my_node', {onTheFly: true}).then((rosNode) => {
 
   // get list of existing publishers, subscribers, and services
   rosNode._node._masterApi.getSystemState("/my_node").then((data) => {
@@ -30,11 +21,11 @@ rosnodejs.initNode('/my_node', {
 
   const TeleportRelative = rosnodejs.require('turtlesim').srv.TeleportRelative;
   const teleport_request = new TeleportRelative.Request({
-    linear: -1, 
+    linear: -1,
     angular: 0.0
   });
 
-  let serviceClient = rosNode.serviceClient("/turtle1/teleport_relative", 
+  let serviceClient = rosNode.serviceClient("/turtle1/teleport_relative",
                                              "turtlesim/TeleportRelative");
 
   rosNode.waitForService(serviceClient.getService(), 2000)
@@ -52,17 +43,17 @@ rosnodejs.initNode('/my_node', {
   // ---------------------------------------------------------
   // Subscribe
   rosNode.subscribe(
-    '/turtle1/pose', 
+    '/turtle1/pose',
     'turtlesim/Pose',
     (data) => {
       console.log('pose', data);
     },
     {queueSize: 1,
-     throttleMs: 1000});
+      throttleMs: 1000});
 
   // ---------------------------------------------------------
   // Publish
-  // equivalent to: 
+  // equivalent to:
   //   rostopic pub /turtle1/cmd_vel geometry_msgs/Twist '[1, 0, 0]' '[0, 0, 0]'
   let cmd_vel = rosNode.advertise('/turtle1/cmd_vel','geometry_msgs/Twist', {
     queueSize: 1,
@@ -85,17 +76,54 @@ rosnodejs.initNode('/my_node', {
 
   // wait two seconds for previous example to complete
   setTimeout(function() {
-    let shapeActionGoal = rosnodejs.require('turtle_actionlib').msg.ShapeActionGoal;
-    let ac = new ActionClient({
-      type: "turtle_actionlib/ShapeAction",
-      actionServer: "/turtle_shape"
+      let shapeActionGoal = rosnodejs.require('turtle_actionlib').msg.ShapeActionGoal;
+      let ac = new ActionClient({
+          type: "turtle_actionlib/ShapeAction",
+          actionServer: "/turtle_shape"
+        });
+      ac.sendGoal(new shapeActionGoal({
+            goal: {
+              edges: 3,
+              radius: 1
+            }
+          }));
+    }, 2000);
+
+  // ---------------------------------------------------------
+  // test int64 + uint64
+
+  rosNode.subscribe(
+    '/int64',
+    'std_msgs/Int64',
+    (data) => {
+      console.log('int64', data);
+    },
+    {queueSize: 1,
+      throttleMs: 1000});
+
+  let int64pub = rosNode.advertise('/int64','std_msgs/Int64', {
+      queueSize: 1,
+      latching: true,
+      throttleMs: 9
     });
-    ac.sendGoal(new shapeActionGoal({
-      goal: {
-        edges: 3,
-        radius: 1
-      }
-    }));
-  }, 2000);
+  const Int64 = rosnodejs.require('std_msgs').msg.Int64;
+  int64pub.publish(new Int64({   data: "429496729456789012" }));
+
+  rosNode.subscribe(
+    '/uint64',
+    'std_msgs/UInt64',
+    (data) => {
+      console.log('uint64', data);
+    },
+    {queueSize: 1,
+      throttleMs: 1000});
+
+  let uint64pub = rosNode.advertise('/uint64','std_msgs/UInt64', {
+      queueSize: 1,
+      latching: true,
+      throttleMs: 9
+    });
+  const UInt64 = rosnodejs.require('std_msgs').msg.UInt64;
+  uint64pub.publish(new UInt64({ data: "9223372036854775807" }));
 
 });

--- a/index.js
+++ b/index.js
@@ -133,15 +133,19 @@ let Rosnodejs = {
     rosNode = new RosNode(nodeName, rosMasterUri);
 
     return new Promise((resolve, reject) => {
-      this.use(options.messages, options.services).then(() => {
+      const connectedToMasterCallback = () => {
+        Logging.initializeOptions(this, options.logging);
+        resolve(this.getNodeHandle());
+      };
 
-        const connectedToMasterCallback = () => {
-          Logging.initializeOptions(this, options.logging);
-          resolve(this.getNodeHandle());
-        };
-
+      if (options.onTheFly) {
+        // generate definitions for all messages and services
+        messages.getAll(function() {
+            _checkMasterHelper(connectedToMasterCallback, 0);
+          });
+      } else {
         _checkMasterHelper(connectedToMasterCallback, 0);
-      });
+      }
     })
     .catch((err) => {
       log.error('Error: ' + err);
@@ -186,68 +190,6 @@ let Rosnodejs = {
       rtv = this.require(parts[0]).srv[parts[1]];
     } catch(e) {}
     return rtv;
-  },
-
-  /** create message classes and services classes for all the given
-   * types before calling callback */
-  use(messages, services) {
-    const self = this;
-    return new Promise((resolve, reject) => {
-      self._useMessages(messages)
-        .then(() => { return self._useServices(services); })
-        .then(() => { resolve(); });
-    });
-  },
-
-  /** create message classes for all the given types */
-  _useMessages(types) {
-    const self = this;
-
-    // make sure required types are available
-    [
-      // for action lib:
-      'actionlib_msgs/GoalStatusArray',
-      'actionlib_msgs/GoalID',
-      // for logging:
-      'rosgraph_msgs/Log',
-    ].forEach(function(type) {
-      if (!self.checkMessage(type)) {
-        // required message definition not available yet, load it
-        // on-demand
-        types.unshift(type);
-      }
-    });
-
-    if (!types || types.length == 0) {
-      return Promise.resolve();
-    }
-    var count = types.length;
-    return new Promise((resolve, reject) => {
-      types.forEach(function(type) {
-        messages.getMessage(type, function(error, Message) {
-          if (--count == 0) {
-            resolve();
-          }
-        });
-      });
-    });
-  },
-
-  /** create service classes for all the given types */
-  _useServices(types) {
-    if (!types || types.length == 0) {
-      return Promise.resolve();
-    }
-    var count = types.length;
-    return new Promise((resolve, reject) => {
-      types.forEach(function(type) {
-        messages.getService(type, function() {
-          if (--count == 0) {
-            resolve();
-          }
-        });
-      });
-    });
   },
 
   /**

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const LogFormatter = require('./utils/log/LogFormatter.js');
 const RosNode = require('./lib/RosNode.js');
 const NodeHandle = require('./lib/NodeHandle.js');
 const Logging = require('./lib/Logging.js');
+const ActionClient = require('./lib/ActionClient.js');
 
 msgUtils.findMessageFiles();
 
@@ -216,6 +217,29 @@ let Rosnodejs = {
       console: ConsoleLogStream,
       ros:     RosLogStream
     }
+  },
+
+
+  //------------------------------------------------------------------
+  // ActionLib
+  //------------------------------------------------------------------
+
+  /**
+    Get an action client for a given type and action server.
+
+    Example:
+      let ac = rosNode.getActionClient({
+        type: "turtle_actionlib/ShapeAction",
+        actionServer: "/turtle_shape"
+      });
+      let shapeActionGoal =
+        rosnodejs.require('turtle_actionlib').msg.ShapeActionGoal;
+      ac.sendGoal(new shapeActionGoal({
+        goal: { edges: 3,  radius: 1 } }));
+   */
+  getActionClient(options) {
+    options.rosnodejs = Rosnodejs;
+    return new ActionClient(options);
   }
 }
 

--- a/lib/ActionClient.js
+++ b/lib/ActionClient.js
@@ -17,7 +17,6 @@
 
 'use strict';
 
-const rosnodejs = require('../index.js');
 const timeUtils = require('../utils/time_utils.js');
 let EventEmitter = require('events');
 
@@ -29,28 +28,29 @@ class ActionClient extends EventEmitter {
 
     this._actionServer = options.actionServer;
 
-    const nh = rosnodejs.nh;
+    this._rosnodejs = options.rosnodejs;
+    const nh = this._rosnodejs.getNodeHandle();
 
     // FIXME: support user options for these parameters
-    this._goalPub = nh.advertise(this._actionServer + '/goal', 
+    this._goalPub = nh.advertise(this._actionServer + '/goal',
                                  this._actionType + 'Goal',
                                  { queueSize: 1, latching: true });
 
-    this._cancelPub = nh.advertise(this._actionServer + '/cancel', 
+    this._cancelPub = nh.advertise(this._actionServer + '/cancel',
                                    'actionlib_msgs/GoalID',
                                    { queueSize: 1, latching: true });
 
-    this._statusSub = nh.subscribe(this._actionServer + '/status', 
+    this._statusSub = nh.subscribe(this._actionServer + '/status',
                                    'actionlib_msgs/GoalStatusArray',
                                    (msg) => { this._handleStatus(msg); },
                                    { queueSize: 1 } );
 
-    this._feedbackSub = nh.subscribe(this._actionServer + '/feedback', 
+    this._feedbackSub = nh.subscribe(this._actionServer + '/feedback',
                                      this._actionType + 'Feedback',
                                      (msg) => { this._handleFeedback(msg); },
                                      { queueSize: 1 } );
 
-    this._statusSub = nh.subscribe(this._actionServer + '/result', 
+    this._statusSub = nh.subscribe(this._actionServer + '/result',
                                    this._actionType + 'Result',
                                    (msg) => { this._handleResult(msg); },
                                    { queueSize: 1 } );
@@ -97,6 +97,19 @@ class ActionClient extends EventEmitter {
     this._goals[goalId] = goal;
 
     this._goalPub.publish(goal);
+    return goal;
+  }
+
+  /** Cancel the given goal. If none is given, send an empty goal message,
+  i.e. cancel all goals. See 
+  http://wiki.ros.org/actionlib/DetailedDescription#The_Messages
+  */
+  cancel(goal) {
+    if (!goal) {
+      let GoalID = this._rosnodejs.require('actionlib_msgs').msg.GoalID;
+      goal = new GoalID();
+    }
+    this._cancelPub.publish(goal);
   }
 
   _generateGoalId() {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "xmlrpc": "chfritz/node-xmlrpc",
     "walker"        : "1.0.7",
     "md5"           : "2.1.0",
-    "async"         : "0.1.22",
+    "async"         : "2.0.1",
     "bunyan": "1.8.1"
   }
 }

--- a/utils/fields.js
+++ b/utils/fields.js
@@ -2,6 +2,17 @@
 
 var fields = exports;
 
+// Try to require bignum package. If available use it for int64 values.
+var bignum;
+try {
+  bignum = require('bignum');
+} catch (e) {}
+
+var BIGNUM_WARNING = `\n** (rosnodejs) WARNING: Using int64 messages without the \
+bignum package is not recommended. You seem to be dealing with numbers larger \
+than 1e15 so precision will be lost!\n`;
+
+
 /* map of all primitive types and their default values */
 var map = {
   'char': '',
@@ -40,7 +51,7 @@ fields.isPrimitive = function(fieldType) {
   return (fields.primitiveTypes.indexOf(fieldType) >= 0);
 };
 
-var isArrayRegex = /.*\[*\]$/;
+var isArrayRegex = /\[*\]$/;
 fields.isArray = function(fieldType) {
   return (fieldType.match(isArrayRegex) !== null);
 };
@@ -82,10 +93,20 @@ fields.parsePrimitive = function(fieldType, fieldValue) {
     parsedValue = Math.abs(parsedValue);
   }
   else if (fieldType === 'int64') {
-    throwUnsupportedInt64Exception();
+    if (bignum) {
+      parsedValue = bignum(fieldValue);
+    } else {
+      parsedValue = parseInt(fieldValue);
+    }
   }
   else if (fieldType === 'uint64') {
-    throwUnsupportedInt64Exception();
+    if (bignum) {
+      parsedValue = bignum(fieldValue);
+      parsedValue = parsedValue.abs();
+    } else {
+      parsedValue = parseInt(fieldValue);
+      parsedValue = Math.abs(parsedValue);
+    }
   }
   else if (fieldType === 'float32') {
     parsedValue = parseFloat(fieldValue);
@@ -108,7 +129,7 @@ fields.parsePrimitive = function(fieldType, fieldValue) {
       }
       var secs = parseInt(now/1000);
       var nsecs = (now % 1000) * 1000;
-      
+
       parsedValue.secs = secs;
       parsedValue.nsecs = nsecs;
     }
@@ -117,7 +138,7 @@ fields.parsePrimitive = function(fieldType, fieldValue) {
   return parsedValue;
 };
 
-fields.serializePrimitive = 
+fields.serializePrimitive =
   function(fieldType, fieldValue, buffer, bufferOffset) {
     if (fieldType === 'bool') {
       buffer.writeUInt8(fieldValue, bufferOffset);
@@ -141,10 +162,56 @@ fields.serializePrimitive =
       buffer.writeUInt32LE(fieldValue, bufferOffset);
     }
     else if (fieldType === 'int64') {
-      throwUnsupportedInt64Exception();
+      if (bignum) {
+        if (!bignum.isBigNum(fieldValue)) {
+          fieldValue = bignum(fieldValue);
+        }
+        var buf = fieldValue.toBuffer({
+            endian: "little",
+            size: 8
+          });
+        buf.copy(buffer, bufferOffset);
+      } else {
+        var high = Math.trunc(fieldValue / 0x100000000);
+        var low = fieldValue % 0x100000000;
+        if (fieldValue < 0) {
+          // constructing two's complement representation
+          // fieldValue = 0x10000000000000000 + fieldValue;
+          // ^ doesn't work, because JS precision is only 53 bits
+          // we'll need to work directly on the parts:
+          // both high and low are negative
+          high = 0x100000000 + high;
+          if (low != 0) {
+            high -= 1;
+          }
+          low = 0x100000000 + low;
+        }
+        // yes, UInt, we've already constructed the two's complement
+        buffer.writeUInt32LE(low, bufferOffset);
+        buffer.writeUInt32LE(high, bufferOffset+4);
+        if (fieldValue >= 1e15) {
+          console.warn(BIGNUM_WARNING);
+        }
+      }
     }
     else if (fieldType === 'uint64') {
-      throwUnsupportedInt64Exception();
+      if (bignum) {
+        if (!bignum.isBigNum(fieldValue)) {
+          fieldValue = bignum(fieldValue);
+        }
+        var high = fieldValue.div(0x100000000).toNumber();
+        var low = fieldValue.mod(0x100000000).toNumber();
+        buffer.writeUInt32LE(low, bufferOffset);
+        buffer.writeUInt32LE(high, bufferOffset+4);
+      } else {
+        var high = Math.trunc(fieldValue / 0x100000000);
+        var low = fieldValue % 0x100000000;
+        buffer.writeUInt32LE(low, bufferOffset);
+        buffer.writeUInt32LE(high, bufferOffset+4);
+        if (fieldValue >= 1e15) {
+          console.warn(BIGNUM_WARNING);
+        }
+      }
     }
     else if (fieldType === 'float32') {
       buffer.writeFloatLE(fieldValue, bufferOffset);
@@ -161,7 +228,7 @@ fields.serializePrimitive =
       buffer.writeUInt32LE(fieldValue.secs, bufferOffset);
       buffer.writeUInt32LE(fieldValue.nsecs, bufferOffset+4);
     }
-    
+
   }
 
 fields.deserializePrimitive = function(fieldType, buffer, bufferOffset) {
@@ -189,10 +256,48 @@ fields.deserializePrimitive = function(fieldType, buffer, bufferOffset) {
     fieldValue = buffer.readUInt32LE(bufferOffset);
   }
   else if (fieldType === 'int64') {
-    throwUnsupportedInt64Exception();
+    if (bignum) {
+      // using bignum package
+      var buf = new Buffer(8);
+      buffer.copy(buf, 0, bufferOffset, bufferOffset+8);
+      fieldValue = bignum.fromBuffer(buf, {
+          endian: "little",
+          size: 8
+        });
+    } else {
+      // no luck, returning an inaccurate 53bit js number
+      var low = buffer.readUInt32LE(bufferOffset);
+      var high = buffer.readUInt32LE(bufferOffset+4);
+      if (high >= 0x10000000) {
+        // the value is negative
+        if (low != 0) {
+          high += 1;
+        }
+        high = high - 0x100000000;
+        low = low - 0x100000000;
+      }
+      fieldValue = high * 0x100000000 + low;
+      if (fieldValue >= 1e15) {
+        console.warn(BIGNUM_WARNING);
+      }
+    }
   }
   else if (fieldType === 'uint64') {
-    throwUnsupportedInt64Exception();
+    if (bignum) {
+      var buf = new Buffer(8);
+      buffer.copy(buf, 0, bufferOffset, bufferOffset+8);
+      fieldValue = bignum.fromBuffer(buf, {
+          endian: "little",
+          size: 8
+        });
+    } else {
+      var low = buffer.readUInt32LE(bufferOffset);
+      var high = buffer.readUInt32LE(bufferOffset+4);
+      fieldValue = high * 0x100000000 + low;
+      if (fieldValue >= 1e15) {
+        console.warn(BIGNUM_WARNING);
+      }
+    }
   }
   else if (fieldType === 'float32') {
     fieldValue = buffer.readFloatLE(bufferOffset);
@@ -311,9 +416,3 @@ fields.getMessageSize = function(message) {
 
   return messageSize;
 }
-
-function throwUnsupportedInt64Exception() {
-  var error = new Error('int64 and uint64 are currently unsupported field types. See https://github.com/baalexander/rosnodejs/issues/2');
-  throw error;
-}
-


### PR DESCRIPTION
Further unified the interfaces of on-the-fly and gennodejs.

See the updated example_turtle.js for the updated syntax. Basically, the specification of which messages and services to use is no longer necessary in the on-the-fly approach. We just generate _all_ message and service definitions on start, which only takes about 500ms. After that they can be accessed just like the gennodejs generated ones using `rosnodejs.require`.

Fixes #14.

Also implemented uint64 and int64 support.
- tested with rostopic; it works, with the usual caveat that
  javascript only uses 53bit precision, so really large numbers get
  "blurry". But the way I've implemented this it is stable, i.e., yes
  large numbers get blurry, but there is no singularity (which there
  could be at the 32bit boundary if one implemented the conversion
  from int64 to unit32 naively).
