### PR TITLE
Small bug fix for constants in on-the-fly message classes

### DIFF
--- a/utils/messages.js
+++ b/utils/messages.js
@@ -272,7 +272,7 @@ function calculateMD5(details, type) {
   function getMD5text(part) {
     var message = '';
     var constants = part.constants.map(function(field) {
-      return field.type + ' ' + field.name + '=' + field.value;
+      return field.type + ' ' + field.name + '=' + field.raw;
     }).join('\n');
 
     var fields = part.fields.map(function(field) {
@@ -348,6 +348,7 @@ function extractFields(content, details, callback) {
             name        : fieldName
             , type        : fieldType
             , value       : parsedConstant
+            , raw         : constant
             , index       : fields.length
             , messageType : null
           });


### PR DESCRIPTION
Prior to this commit constant values like "1.0", i.e., floats that are
integer, were not correctly treated in the md5sum calculation -- they
were abbreviated to "1", causing incorrect md5sums. This commit fixes
that by using the original string value for md5sum calculation.
