### PR TITLE
Full Message Definition, Fix ros bags

### DIFF
--- a/examples/standard.js
+++ b/examples/standard.js
@@ -58,7 +58,7 @@ rosnodejs.initNode('/test_node')
   let iter = 0;
   const msg = new std_msgs.String();
   setInterval(() => {
-    msg.data = msgStart + iter
+    msg.data = msgStart + iter;
     pub.publish(msg);
     ++iter;
     if (iter > 200) {

--- a/index.js
+++ b/index.js
@@ -152,6 +152,10 @@ let Rosnodejs = {
     rosNode = null;
   },
 
+  shutdown() {
+    return rosNode.shutdown();
+  },
+
   _loadOnTheFlyMessages({onTheFly}) {
     if (onTheFly) {
       return new Promise((resolve, reject) => {

--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -203,7 +203,8 @@ class Publisher extends EventEmitter {
         this._nodeHandle.getNodeName(),
         this._messageHandler.md5sum(),
         this.getType(),
-        this.getLatching());
+        this.getLatching(),
+        this._messageHandler.messageDefinition().trim());
     subscriber.write(respHeader);
 
     // if this publisher had the tcpNoDelay option set

--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -204,7 +204,7 @@ class Publisher extends EventEmitter {
         this._messageHandler.md5sum(),
         this.getType(),
         this.getLatching(),
-        this._messageHandler.messageDefinition().trim());
+        this._messageHandler.messageDefinition());
     subscriber.write(respHeader);
 
     // if this publisher had the tcpNoDelay option set

--- a/lib/RosNode.js
+++ b/lib/RosNode.js
@@ -539,16 +539,15 @@ class RosNode extends EventEmitter {
       // remove subscribers first so that master doesn't send
       // publisherUpdate messages
       Object.keys(this._subscribers).forEach((topic) => {
-        promises.push(this.unregisterSubscriber(topic));
+        promises.push(this.unsubscribe(topic));
       });
 
       Object.keys(this._publishers).forEach((topic) => {
-        promises.push(this.unregisterPublisher(topic));
+        promises.push(this.unadvertise(topic));
       });
 
       Object.keys(this._services).forEach((service) => {
-        let serv = this._services[service];
-        promises.push(this.unregisterService(service));
+        promises.push(this.unadvertiseService(service));
       });
 
       if (killProcess) {

--- a/lib/Subscriber.js
+++ b/lib/Subscriber.js
@@ -249,7 +249,8 @@ class Subscriber extends EventEmitter {
   }
 
   _createTcprosHandshake() {
-    return TcprosUtils.createSubHeader(this._nodeHandle.getNodeName(), this._messageHandler.md5sum(), this.getTopic(), this.getType());
+    return TcprosUtils.createSubHeader(this._nodeHandle.getNodeName(), this._messageHandler.md5sum(),
+                                       this.getTopic(), this.getType(), this._messageHandler.messageDefinition().trim());
   }
 
   _handleMessage(client, msg) {

--- a/lib/Subscriber.js
+++ b/lib/Subscriber.js
@@ -250,7 +250,7 @@ class Subscriber extends EventEmitter {
 
   _createTcprosHandshake() {
     return TcprosUtils.createSubHeader(this._nodeHandle.getNodeName(), this._messageHandler.md5sum(),
-                                       this.getTopic(), this.getType(), this._messageHandler.messageDefinition().trim());
+                                       this.getTopic(), this.getType(), this._messageHandler.messageDefinition());
   }
 
   _handleMessage(client, msg) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bunyan": "1.8.1",
     "md5": "2.1.0",
     "moment": "2.12.0",
-    "ros_msg_utils": "RethinkRobotics-opensource/ros_msg_utils#v1.0.1",
+    "ros_msg_utils": "1.0.2",
     "walker": "1.0.7",
     "xmlrpc": "chfritz/node-xmlrpc"
   }

--- a/test/gennodejsTest.js
+++ b/test/gennodejsTest.js
@@ -449,6 +449,9 @@ describe('gennodejsTests', () => {
       basicServiceResp = new BasicService.Response({result: stringField});
 
       expect(basicServiceResp.result).to.equal(stringField);
+
+      // expect full message definition (including test_msgs/BaseType)
+      expect(BaseTypeVariableLengthArray.messageDefinition().includes(BaseType.messageDefinition().trim())).to.be.true;
     });
 
     it('constant length arrays', (done) => {
@@ -680,6 +683,9 @@ describe('gennodejsTests', () => {
       expect(deserializedMsg.time_field.secs).to.equal(time.secs);
       expect(deserializedMsg.time_field.nsecs).to.equal(time.nsecs);
 
+      // check message definition is full message definition (including message it depends on)
+      expect(StdMsg.messageDefinition().includes(Header.messageDefinition().trim())).to.be.true;
+
       done();
     });
 
@@ -745,6 +751,49 @@ describe('gennodejsTests', () => {
       expect(msgUtils.getHandlerForMsgType('test_msgs/TestActionAction')).to.not.throw;
       expect(msgUtils.getHandlerForMsgType('test_msgs/TestActionFeedback')).to.not.throw;
       expect(msgUtils.getHandlerForMsgType('test_msgs/TestActionGoal')).to.not.throw;
+    });
+
+    it('Message Definition', () => {
+      const TestActionActionGoal = msgUtils.getHandlerForMsgType('test_msgs/TestActionActionGoal');
+      const TestActionActionFeedback = msgUtils.getHandlerForMsgType('test_msgs/TestActionActionFeedback');
+      const TestActionActionResult = msgUtils.getHandlerForMsgType('test_msgs/TestActionActionResult');
+      const TestActionGoal = msgUtils.getHandlerForMsgType('test_msgs/TestActionGoal');
+      const TestActionFeedback = msgUtils.getHandlerForMsgType('test_msgs/TestActionFeedback');
+      const TestActionResult = msgUtils.getHandlerForMsgType('test_msgs/TestActionResult');
+
+      const actionGoalMsgDefinition = TestActionActionGoal.messageDefinition().trim();
+      const actionFeedbackMsgDefinition = TestActionActionFeedback.messageDefinition().trim();
+      const actionResultMsgDefinition = TestActionActionResult.messageDefinition().trim();
+      const goalMsgDefinition = TestActionGoal.messageDefinition().trim();
+      const feedbackMsgDefinition = TestActionFeedback.messageDefinition().trim();
+      const resultMsgDefinition = TestActionResult.messageDefinition().trim();
+
+      expect(goalMsgDefinition.includes('---')).to.be.false;
+      expect(goalMsgDefinition.includes(feedbackMsgDefinition)).to.be.false;
+      expect(goalMsgDefinition.includes(resultMsgDefinition)).to.be.false;
+
+      expect(feedbackMsgDefinition.includes('---')).to.be.false;
+      expect(feedbackMsgDefinition.includes(goalMsgDefinition)).to.be.false;
+      expect(feedbackMsgDefinition.includes(resultMsgDefinition)).to.be.false;
+
+      expect(resultMsgDefinition.includes('---')).to.be.false;
+      expect(resultMsgDefinition.includes(feedbackMsgDefinition)).to.be.false;
+      expect(resultMsgDefinition.includes(goalMsgDefinition)).to.be.false;
+
+      expect(actionGoalMsgDefinition.includes('---')).to.be.false;
+      expect(actionGoalMsgDefinition.includes(goalMsgDefinition)).to.be.true;
+      expect(actionGoalMsgDefinition.includes(feedbackMsgDefinition)).to.be.false;
+      expect(actionGoalMsgDefinition.includes(resultMsgDefinition)).to.be.false;
+
+      expect(actionFeedbackMsgDefinition.includes('---')).to.be.false;
+      expect(actionFeedbackMsgDefinition.includes(goalMsgDefinition)).to.be.false;
+      expect(actionFeedbackMsgDefinition.includes(feedbackMsgDefinition)).to.be.true;
+      expect(actionFeedbackMsgDefinition.includes(resultMsgDefinition)).to.be.false;
+
+      expect(actionResultMsgDefinition.includes('---')).to.be.false;
+      expect(actionResultMsgDefinition.includes(goalMsgDefinition)).to.be.false;
+      expect(actionResultMsgDefinition.includes(feedbackMsgDefinition)).to.be.false;
+      expect(actionResultMsgDefinition.includes(resultMsgDefinition)).to.be.true;
     });
   });
 

--- a/utils/messageGeneration/MessageSpec.js
+++ b/utils/messageGeneration/MessageSpec.js
@@ -156,16 +156,17 @@ class RosMsgSpec {
 
   /**
    * Tries to load and parse message file
-   * @param filePath {string|null} path to file - will load file from here if provided
-   * @param fileContents {string|null} file contents - will parse into desired fields
+   * @param [filePath] {string} path to file - will load file from here if provided
+   * @param [fileContents] {string} file contents - will parse into desired fields
    */
   loadFile(filePath=null, fileContents=null) {
-    this.fileContents = fileContents;
 
     if (filePath !== null) {
-      this._loadMessageFile(filePath);
+      fileContents = this._loadMessageFile(filePath);
     }
-    if (this.fileContents !== null) {
+    if (fileContents !== null) {
+      this.fileContents = this._extractRelevantMessage(fileContents);
+
       this._extractFields(this.fileContents);
     }
   }
@@ -207,12 +208,13 @@ class RosMsgSpec {
   }
 
   /**
-   * Reads file at specified location and caches its contents
+   * Reads file at specified location and returns its contents
    * @param fileName {string}
+   * @returns fileContents {string}
    * @private
    */
   _loadMessageFile(fileName) {
-    this.fileContents = fs.readFileSync(fileName, 'utf8');
+    return fs.readFileSync(fileName, 'utf8');
   }
 
   /**
@@ -285,13 +287,14 @@ class RosMsgSpec {
   };
 
   /**
-   * Parses through message definition for fields and constants
-   * Todo: move this to MsgSpec?
-   * @param content {string} raw message definition
+   * Takes a full definition and pulls out the piece relevant to this specific message spec
+   * (e.g. only the goal from the action message or only the request from the service message)
+   * @param fileContents string
+   * @returns {string}
    * @private
    */
-  _extractFields(content) {
-    let lines = content.split('\n').map((line) => line.trim());
+  _extractRelevantMessage(fileContents) {
+    let lines = fileContents.split('\n').map((line) => line.trim());
 
     switch (this.type) {
       case SRV_REQUEST_TYPE: {
@@ -325,6 +328,18 @@ class RosMsgSpec {
         break;
     }
 
+    return lines.join('\n');
+  }
+
+  /**
+   * Parses through message definition for fields and constants
+   * Todo: move this to MsgSpec?
+   * @param content {string} raw message definition
+   * @private
+   */
+  _extractFields(content) {
+    let lines = content.split('\n').map((line) => line.trim());
+
     lines.forEach(this._parseLine.bind(this));
   }
 
@@ -342,6 +357,40 @@ class RosMsgSpec {
    */
   getMd5sum() {
     return md5(this.getMd5text());
+  }
+
+  /**
+   * Generates a depth-first list of all dependencies of this message in field order.
+   * @param [deps] {Array}
+   * @returns {Array}
+   */
+  getFullDependencies(deps = []) {
+    return [];
+  }
+
+  /**
+   * Computes the full text of a message/service.
+   * Necessary for rosbags.
+   * Mirrors gentools.
+   * See compute_full_text() in
+   *   https://github.com/ros/ros/blob/kinetic-devel/core/roslib/src/roslib/gentools.py
+   */
+  computeFullText() {
+    const w = new IndentedWriter();
+
+    const deps = this.getFullDependencies();
+    const sep = '='.repeat(80);
+    w.write(this.fileContents.trim())
+      .newline();
+
+    deps.forEach((dep) => {
+      w.write(sep)
+        .write(`MSG: ${dep.getFullMessageName()}`)
+        .write(dep.fileContents.trim())
+        .newline();
+    });
+
+    return w.get().trim();
   }
 }
 
@@ -472,6 +521,25 @@ class MsgSpec extends RosMsgSpec {
   generateMessageClassFile() {
     return MessageWriter.createMessageClass(this);
   }
+
+  /**
+   * Generates a depth-first list of all dependencies of this message in field order.
+   * @param [deps] {Array}
+   * @returns {Array}
+   */
+  getFullDependencies(deps = []) {
+    this.fields.forEach((field) => {
+      if (!field.isBuiltin) {
+        const fieldSpec = this.getMsgSpecForType(field.baseType);
+        if (deps.indexOf(fieldSpec) === -1) {
+          deps.push(fieldSpec);
+        }
+        fieldSpec.getFullDependencies(deps);
+      }
+    });
+
+    return deps;
+  }
 }
 
 /**
@@ -483,7 +551,7 @@ class SrvSpec extends RosMsgSpec {
   constructor(msgCache, packageName, messageName, type, filePath=null) {
     super(msgCache, packageName, messageName, type, filePath);
 
-    this._loadMessageFile(filePath);
+    this.fileContents = this._loadMessageFile(filePath);
 
     this.request = new MsgSpec(msgCache, packageName, messageName + 'Request', SRV_REQUEST_TYPE, null, this.fileContents);
     this.response = new MsgSpec(msgCache, packageName, messageName + 'Response', SRV_RESPONSE_TYPE, null, this.fileContents);
@@ -519,7 +587,7 @@ class ActionSpec extends RosMsgSpec {
   constructor(msgCache, packageName, messageName, type, filePath=null) {
     super(msgCache, packageName, messageName, type, filePath);
 
-    this._loadMessageFile(filePath);
+    this.fileContents = this._loadMessageFile(filePath);
 
     // Parse the action definition into its 3 respective parts
     this.goal = new MsgSpec(msgCache, packageName, messageName + 'Goal', ACTION_GOAL_TYPE, null, this.fileContents);

--- a/utils/messageGeneration/MessageWriter.js
+++ b/utils/messageGeneration/MessageWriter.js
@@ -579,11 +579,8 @@ function writeMessageDefinition(w, spec) {
     .indent('// Returns full string definition for message')
     .write('return `');
 
-  const lines = spec.fileContents.split('\n');
-  lines.forEach((line) => {
-    w.write(`${line}`);
-  });
-  w.write('`;')
+  const fullText = spec.computeFullText();
+  w.write(`${fullText}\n\`;`)
     .dedent('}')
     .newline();
 }

--- a/utils/messageGeneration/packages.js
+++ b/utils/messageGeneration/packages.js
@@ -183,7 +183,7 @@ function findPackageInDirectoryChain(directories, packageName, callback) {
 function findPackagesInDirectoryChain(directories) {
   const funcs = directories.map((directory) => { return findPackagesInDirectory.bind(null, directory); });
   return funcs.reduce((prev, cur, index) => {
-    return prev.then(() => {console.log('search ' + directories[index]); return cur(); });
+    return prev.then(() => { return cur(); });
   }, Promise.resolve());
 }
 

--- a/utils/tcpros_utils.js
+++ b/utils/tcpros_utils.js
@@ -125,7 +125,7 @@ let TcprosUtils = {
 
     const fields = deserializeStringFields(header);
     fields.forEach((field) => {
-      let matchResult = field.match(/^(\w+)=(.+)/m);
+      let matchResult = field.match(/^(\w+)=([\s\S]+)/);
 
       // invalid connection header
       if (!matchResult) {

--- a/utils/tcpros_utils.js
+++ b/utils/tcpros_utils.js
@@ -30,7 +30,8 @@ const servicePrefix = 'service=';
 const typePrefix = 'type=';
 const latchingPrefix = 'latching=';
 const persistentPrefix = 'persistent=';
-const errorPrefix = 'error='
+const errorPrefix = 'error=';
+const messageDefinitionPrefix = 'message_definition=';
 
 //-----------------------------------------------------------------------
 
@@ -59,24 +60,40 @@ function deserializeStringFields(buffer) {
   return fields;
 }
 
+/**
+ * NOTE for general questions see
+ * http://wiki.ros.org/ROS/TCPROS
+ */
 let TcprosUtils = {
 
-  createSubHeader(callerId, md5sum, topic, type) {
+  createSubHeader(callerId, md5sum, topic, type, messageDefinition) {
     const fields = [
       callerIdPrefix + callerId,
       md5Prefix + md5sum,
       topicPrefix + topic,
-      typePrefix + type
+      typePrefix + type,
+      messageDefinitionPrefix + messageDefinition
     ];
     return serializeStringFields(fields);
   },
 
-  createPubHeader(callerId, md5sum, type, latching) {
+  /**
+   * Creates a TCPROS connection header for a publisher to send.
+   * @param callerId {string} node publishing this topic
+   * @param md5sum {string} md5 of the message
+   * @param type {string} type of the message
+   * @param latching {number} 0 or 1 indicating if the topic is latching
+   * @param messageDefinition {string} trimmed message definition.
+   *          rosbag relies on this being sent although it is not mentioned in the spec.
+   *
+   */
+  createPubHeader(callerId, md5sum, type, latching, messageDefinition) {
     const fields = [
       callerIdPrefix + callerId,
       md5Prefix + md5sum,
       typePrefix + type,
-      latchingPrefix + latching
+      latchingPrefix + latching,
+      messageDefinitionPrefix + messageDefinition
     ];
     return serializeStringFields(fields);
   },


### PR DESCRIPTION
- Calculates the full message definition for generated code.
- Includes message definition in publisher, subscriber connection headers
- tests for message definitions
- adds back shutdown call that was lost somehow

Bagged complicated message - fixed, played, opened with `rqt_bag`
`gennodejs` should already calculate the full message definition so I believe its messages will now also work for ros bags (we should test this).