### PR TITLE
Fix tests

### DIFF
--- a/test/Log.js
+++ b/test/Log.js
@@ -39,13 +39,16 @@ describe('Logging', () => {
   };
 
   before(() => {
-    rosnodejs.log.addStream({
-      type: 'raw',
-      level: 'info',
-      stream: outputCapture
-    });
+    return rosnodejs.initNode('/testNode', {rosMasterUri: `http://localhost:${MASTER_PORT}`, logging: {skipRosLogging: true}})
+      .then(() => {
+        rosnodejs.log.addStream({
+          type: 'raw',
+          level: 'info',
+          stream: outputCapture
+        });
 
-    rosnodejs.log.setLevel('trace');
+        rosnodejs.log.setLevel('trace');
+      });
   });
 
   after(()=> {

--- a/test/onTheFly.js
+++ b/test/onTheFly.js
@@ -1,40 +1,61 @@
-'use strict'
+'use strict';
 
 const chai = require('chai');
 const expect = chai.expect;
-let rosnodejs = require('../index.js');
+const xmlrpc = require('xmlrpc');
+const rosnodejs = require('../index.js');
+const Master = require('./utils/MasterStub.js');
 
-rosnodejs.initNode('/my_node', { onTheFly: true})
-  .then((rosNode) => {
+const MASTER_PORT = 11234;
 
-    const geometry_msgs = rosnodejs.require('geometry_msgs').msg;
-    const msg = new geometry_msgs.PoseWithCovariance({
-        pose: {
-          position: {x:0, y:0, z:0},
-          orientation: {w:1, x:0, y:0, z:0}
-        },
-        covariance: [
-          0,0,0,0,0,0.123,
-          0,2,0,0,0,0,
-          0,0,4,0,0,0,
-          0,0,0,6,0,0,
-          0,0,0,0,8,0,
-          0.123,0,0,0,0,0.654321654321
-        ]
-      });
+describe('OnTheFly', function () {
+  let master;
 
-    describe('OnTheFly', () => {
+  before(function (done) {
+    this.timeout(0);
 
-        it('serialize/deserialize', (done) => {
-            const size = geometry_msgs.PoseWithCovariance.getMessageSize(msg);
-            const buffer = new Buffer(size);
-            geometry_msgs.PoseWithCovariance.serialize(msg, buffer, 0);
+    master = new Master('localhost', MASTER_PORT);
+    master.provideAll();
 
-            const read = geometry_msgs.PoseWithCovariance.deserialize(buffer);
-            expect(read.covariance.length == msg.covariance.length
-              && read.covariance.every((v,i)=> v === msg.covariance[i])).to.be.true;
-
-            done();
-          });
+    return rosnodejs.initNode('/testNode', {
+      rosMasterUri: `http://localhost:${MASTER_PORT}`,
+      onTheFly: true,
+      logging: {skipRosLogging: true}})
+      .then(() => {
+        done();
       });
   });
+
+  after(() => {
+    rosnodejs.reset();
+    return master.shutdown();
+  });
+
+  const geometry_msgs = rosnodejs.require('geometry_msgs').msg;
+  const msg = new geometry_msgs.PoseWithCovariance({
+      pose: {
+        position: {x:0, y:0, z:0},
+        orientation: {w:1, x:0, y:0, z:0}
+      },
+      covariance: [
+        0,0,0,0,0,0.123,
+        0,2,0,0,0,0,
+        0,0,4,0,0,0,
+        0,0,0,6,0,0,
+        0,0,0,0,8,0,
+        0.123,0,0,0,0,0.654321654321
+      ]
+    });
+
+  it('serialize/deserialize', (done) => {
+    const size = geometry_msgs.PoseWithCovariance.getMessageSize(msg);
+    const buffer = new Buffer(size);
+    geometry_msgs.PoseWithCovariance.serialize(msg, buffer, 0);
+
+    const read = geometry_msgs.PoseWithCovariance.deserialize(buffer);
+    expect(read.covariance.length == msg.covariance.length
+      && read.covariance.every((v,i)=> v === msg.covariance[i])).to.be.true;
+
+    done();
+  });
+});

--- a/test/utils/MasterStub.js
+++ b/test/utils/MasterStub.js
@@ -1,0 +1,52 @@
+const xmlrpc = require('xmlrpc');
+const EventEmitter = require('events').EventEmitter;
+
+class RosMasterStub extends EventEmitter {
+  constructor(host, port) {
+    super();
+
+    this._host = host;
+    this._port = port;
+
+    this._server = xmlrpc.createServer({host, port}, () => {
+      this.emit('ready');
+    });
+
+    this._server.on('NotFound', (method, params) => {
+      console.error('Method %s does not exist', method);
+    });
+
+    this._apiMap = {
+      getUri: this._onGetUri.bind(this)
+    };
+
+    this._providedApis = new Set();
+  }
+
+  shutdown() {
+    return new Promise((resolve, reject) => {
+      this._server.close(resolve);
+    });
+  }
+
+  provide(api) {
+    const method = this._apiMap[api];
+    if (method && !this._providedApis.has(api)) {
+      this._server.on(api, method);
+      this._providedApis.add(api);
+    }
+  }
+
+  provideAll() {
+    Object.keys(this._apiMap).forEach((api) => {
+      this.provide(api);
+    });
+  }
+
+  _onGetUri(err, params, callback) {
+    const resp = [ 1, '', `${this._host}:${this._port}`];
+    callback(null, resp);
+  }
+}
+
+module.exports = RosMasterStub;


### PR DESCRIPTION
Issues with how tests were interacting with the ros master and each other were causing some of them to break. Creates a cheap master stub that, for now, only provides `getUri`. Tests are passing again.