### PR TITLE
add datatype function to generated message class

### DIFF
--- a/utils/messageGeneration/messages.js
+++ b/utils/messageGeneration/messages.js
@@ -546,6 +546,7 @@ function buildMessageClass(details) {
     return message;
   };
   Message.getMessageSize = function(msg) { return fieldsUtil.getMessageSize(msg); };
+  Message.datatype = function() { return details.messageType; };
 
   return Message;
 }


### PR DESCRIPTION
Fixes an issue discovered in #45 when using the message class in advertise, subscribe calls