### PR TITLE
Multiple pub subs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bunyan": "1.8.1",
     "md5": "2.1.0",
     "moment": "2.12.0",
+    "ultron": "1.1.0",
     "walker": "1.0.7",
     "xmlrpc": "chfritz/node-xmlrpc"
   }

--- a/src/lib/Logging.js
+++ b/src/lib/Logging.js
@@ -239,6 +239,10 @@ class LoggingManager {
     this._forEachLogger((logger) => logger.clearExpiredThrottledLogs(), true);
   }
 
+  stopLogCleanup() {
+    clearInterval(this._cleanLoggersInterval);
+  }
+
   _handleGetLoggers(req, resp) {
     if (this._externalLog.getLoggers !== null) {
       this._externalLog.getLoggers(req, resp);

--- a/src/lib/MasterApiClient.js
+++ b/src/lib/MasterApiClient.js
@@ -36,8 +36,8 @@ class MasterApiClient {
     return this._xmlrpcClient;
   }
 
-  _call(method, data, resolve, reject) {
-    this._xmlrpcClient.call(method, data, resolve, reject);
+  _call(method, data, resolve, reject, options) {
+    this._xmlrpcClient.call(method, data, resolve, reject, options);
   }
 
   registerService(callerId, service, serviceUri, uri) {

--- a/src/lib/Publisher.js
+++ b/src/lib/Publisher.js
@@ -17,106 +17,72 @@
 
 "use strict";
 
-const SerializationUtils = require('../utils/serialization_utils.js');
-const Serialize = SerializationUtils.Serialize;
-const TcprosUtils = require('../utils/tcpros_utils.js');
 const EventEmitter = require('events');
-const Logging = require('./Logging.js');
-const {REGISTERING, REGISTERED, SHUTDOWN} = require('../utils/ClientStates.js');
+const {rebroadcast} = require('../utils/event_utils.js');
 
 class Publisher extends EventEmitter {
-  constructor(options, nodeHandle) {
+  constructor(impl) {
     super();
-    this._topic = options.topic;
 
-    this._type = options.type;
+    ++impl.count;
+    this._impl = impl;
 
-    this._latching = !!options.latching;
-
-    this._tcpNoDelay =  !!options.tcpNoDelay;
-
-
-    if (options.queueSize) {
-      this._queueSize = options.queueSize;
-    }
-    else {
-      this._queueSize = 1;
-    }
-
-    /**
-     * throttleMs interacts with queueSize to determine when to send
-     * messages.
-     *  < 0  : send immediately - no interaction with queue
-     * >= 0 : place event at end of event queue to publish message
-         after minimum delay (MS)
-     */
-    if (options.hasOwnProperty('throttleMs')) {
-      this._throttleMs = options.throttleMs;
-    }
-    else {
-      this._throttleMs = 0;
-    }
-
-    // OPTIONS STILL NOT HANDLED:
-    //  headers: extra headers to include
-    //  subscriber_listener: callback for new subscribers connect/disconnect
-
-    this._resolve = !!options.resolve;
-
-    this._lastSentMsg = null;
-
-    this._nodeHandle = nodeHandle;
-    this._nodeHandle.getSpinner().addClient(this, this._getSpinnerId(), this._queueSize, this._throttleMs);
-
-    this._log = Logging.getLogger('ros.rosnodejs');
-
-    this._subClients = {};
-
-    this._messageHandler = options.typeClass;
-
-    this._state = REGISTERING;
-    this._register();
-  }
-
-  _getSpinnerId() {
-    return `Publisher://${this.getTopic()}`;
+    rebroadcast('registered', this._impl, this);
+    rebroadcast('connection', this._impl, this);
+    rebroadcast('disconnect', this._impl, this);
+    rebroadcast('error', this._impl, this);
   }
 
   getTopic() {
-    return this._topic;
+    if (this._impl) {
+      return this._impl.getTopic();
+    }
+    // else
+    return null;
   }
 
   getType() {
-    return this._type;
+    if (this._impl) {
+      return this._impl.getType();
+    }
+    // else
+    return null;
   }
 
   getLatching() {
-    return this._latching;
+    if (this._impl) {
+      return this._impl.getLatching();
+    }
+    // else
+    return false;
   }
 
   getNumSubscribers() {
-    return Object.keys(this._subClients).length;
+    if (this._impl) {
+      return this._impl.getNumSubscribers();
+    }
+    // else
+    return 0;
   }
 
   shutdown() {
-    this._nodeHandle.unadvertise(this.getTopic());
+    const topic= this.getTopic();
+    if (this._impl) {
+      const impl = this._impl
+      this._impl = null;
+      this.removeAllListeners();
+
+      --impl.count;
+      if (impl.count <= 0) {
+        return impl.shutdown();
+      }
+    }
+    // else
+    return Promise.resolve();
   }
 
   isShutdown() {
-    return this._state === SHUTDOWN;
-  }
-
-  disconnect() {
-    this._state = SHUTDOWN;
-
-    Object.keys(this._subClients).forEach((clientId) => {
-      const client = this._subClients[clientId];
-      client.end();
-    });
-
-    // disconnect from the spinner in case we have any pending callbacks
-    this._nodeHandle.getSpinner().disconnect(this._getSpinnerId());
-    this._subClients = {};
+    return !!this._impl;
   }
 
   /**
@@ -126,141 +92,7 @@ class Publisher extends EventEmitter {
    * @param [throttleMs] {number} optional override for publisher setting
    */
   publish(msg, throttleMs) {
-    if (this.isShutdown()) {
-      return;
-    }
-
-    if (typeof throttleMs !== 'number') {
-      throttleMs = this._throttleMs;
-    }
-
-    if (throttleMs < 0) {
-      // short circuit JS event queue, publish "synchronously"
-      this._handleMsgQueue([msg]);
-    }
-    else {
-      this._nodeHandle.getSpinner().ping(this._getSpinnerId(), msg);
-    }
-  }
-
-  /**
-   * Pulls all msgs off queue, serializes, and publishes them
-   */
-  _handleMsgQueue(msgQueue) {
-
-    // There's a small chance that we were shutdown while the spinner was locked
-    // which could cause _handleMsgQueue to be called if this publisher was in there.
-    if (this.isShutdown()) {
-      return;
-    }
-
-    const numClients = this.getNumSubscribers();
-    if (numClients === 0) {
-      this._log.debugThrottle(2000, `Publishing message on ${this.getTopic()} with no subscribers`);
-    }
-
-    try {
-      msgQueue.forEach((msg) => {
-        if (this._resolve) {
-          msg = this._messageHandler.Resolve(msg);
-        }
-
-        const serializedMsg = TcprosUtils.serializeMessage(this._messageHandler, msg);
-
-        Object.keys(this._subClients).forEach((client) => {
-          this._subClients[client].write(serializedMsg);
-        });
-
-        // if this publisher is supposed to latch,
-        // save the last message. Any subscribers that connect
-        // before another call to publish() will receive this message
-        if (this.getLatching()) {
-          this._lastSentMsg = serializedMsg;
-        }
-      });
-    }
-    catch (err) {
-      this._log.error('Error when publishing message on topic %s: %s', this.getTopic(), err.stack);
-      this.emit('error', err);
-    }
-  }
-
-  handleSubscriberConnection(subscriber, header) {
-    let error = TcprosUtils.validateSubHeader(
-      header, this.getTopic(), this.getType(),
-      this._messageHandler.md5sum());
-    if (error !== null) {
-      this._log.error('Unable to validate subscriber connection header '
-                      + JSON.stringify(header));
-      subscriber.end(Serialize(error));
-      return;
-    }
-    // else
-    this._log.info('Pub %s got connection header %s', this.getTopic(), JSON.stringify(header));
-
-    // create and send response
-    let respHeader =
-      TcprosUtils.createPubHeader(
-        this._nodeHandle.getNodeName(),
-        this._messageHandler.md5sum(),
-        this.getType(),
-        this.getLatching(),
-        this._messageHandler.messageDefinition());
-    subscriber.write(respHeader);
-
-    // if this publisher had the tcpNoDelay option set
-    // disable the nagle algorithm
-    if  (this._tcpNoDelay) {
-      subscriber.setNoDelay(true);
-    }
-
-    subscriber.on('close', () => {
-      this._log.info('Publisher %s client %s disconnected!',
-                      this.getTopic(), subscriber.name);
-      delete this._subClients[subscriber.name];
-      this.emit('disconnect');
-    });
-
-    subscriber.on('end', () => {
-      this._log.info('Sub %s sent END', subscriber.name);
-    });
-
-    subscriber.on('error', () => {
-      this._log.warn('Sub %s had error', subscriber.name);
-    });
-
-    if (this._lastSentMsg !== null) {
-      this._log.debug('Sending latched msg to new subscriber');
-      subscriber.write(this._lastSentMsg);
-    }
-
-    // if handshake good, add to list, we'll start publishing to it
-    this._subClients[subscriber.name] = subscriber;
-
-    this.emit('connection', header, subscriber.name);
-  }
-
-  _register() {
-    this._nodeHandle.registerPublisher(this._topic, this._type)
-    .then((resp) => {
-      // if we were shutdown between the starting the registration and now, bail
-      if (this.isShutdown()) {
-        return;
-      }
-
-      this._log.info('Registered %s as a publisher: %j', this._topic, resp);
-      let code = resp[0];
-      let msg = resp[1];
-      let subs = resp[2];
-      if (code === 1) {
-        // registration worked
-        this._state = REGISTERED;
-        this.emit('registered');
-      }
-    })
-    .catch((err) => {
-      this._log.error('Error while registering publisher %s: %s', this.getTopic(), err);
-    })
+    this._impl.publish(msg, throttleMs);
   }
 }
 

--- a/src/lib/Publisher.js
+++ b/src/lib/Publisher.js
@@ -18,6 +18,7 @@
 "use strict";
 
 const EventEmitter = require('events');
+const Ultron = require('ultron');
 const {rebroadcast} = require('../utils/event_utils.js');
 
 /**
@@ -31,14 +32,15 @@ class Publisher extends EventEmitter {
 
     ++impl.count;
     this._impl = impl;
+    this._ultron = new Ultron(impl);
 
     this._topic = impl.getTopic();
     this._type = impl.getType();
 
-    rebroadcast('registered', this._impl, this);
-    rebroadcast('connection', this._impl, this);
-    rebroadcast('disconnect', this._impl, this);
-    rebroadcast('error', this._impl, this);
+    rebroadcast('registered', this._ultron, this);
+    rebroadcast('connection', this._ultron, this);
+    rebroadcast('disconnect', this._ultron, this);
+    rebroadcast('error', this._ultron, this);
   }
 
   /**
@@ -92,6 +94,8 @@ class Publisher extends EventEmitter {
     if (this._impl) {
       const impl = this._impl
       this._impl = null;
+      this._ultron.destroy();
+      this._ultron = null;
 
       --impl.count;
       if (impl.count <= 0) {

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -139,7 +139,7 @@ class RosNode extends EventEmitter {
     if (sub) {
       this._debugLog.info('Unsubscribing from topic %s', topic);
       delete this._subscribers[topic];
-      sub._shutdown();
+      sub.shutdown();
       return this.unregisterSubscriber(topic);
     }
   }
@@ -149,7 +149,7 @@ class RosNode extends EventEmitter {
     if (pub) {
       this._debugLog.info('Unadvertising topic %s', topic);
       delete this._publishers[topic];
-      pub._shutdown();
+      pub.shutdown();
       return this.unregisterPublisher(topic);
     }
   }
@@ -537,7 +537,42 @@ class RosNode extends EventEmitter {
   }
 
   _handleGetBusInfo(err, params, callback) {
-    this._log.error('Not implemented');
+    const busInfo = [];
+    let count = 0;
+    Object.keys(this._subscribers).forEach((topic) => {
+      const sub = this._subscribers[topic];
+      sub.getClientUris().forEach((clientUri) => {
+        busInfo.push([
+          ++count,
+          clientUri,
+          'i',
+          'TCPROS',
+          sub.getTopic(),
+          true
+        ]);
+      });
+    });
+
+    Object.keys(this._publishers).forEach((topic) => {
+      const pub = this._publishers[topic];
+      pub.getClientUris().forEach((clientUri) => {
+        busInfo.push([
+          ++count,
+          clientUri,
+          'o',
+          'TCPROS',
+          pub.getTopic(),
+          true
+        ]);
+      });
+    });
+
+    const resp = [
+      1,
+      this.getNodeName(),
+      busInfo
+    ];
+    callback(null, resp);
   }
 
   _handleGetBusStats(err, params, callback) {

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -24,6 +24,8 @@ let SlaveApiClient = require('./SlaveApiClient.js');
 let ParamServerApiClient = require('./ParamServerApiClient.js');
 let Subscriber = require('./Subscriber.js');
 let Publisher = require('./Publisher.js');
+const PublisherImpl = require('./impl/PublisherImpl.js');
+const SubscriberImpl = require('./impl/SubscriberImpl.js');
 let ServiceClient = require('./ServiceClient.js');
 let ServiceServer = require('./ServiceServer.js');
 const Spinner = require('../utils/GlobalSpinner.js');
@@ -93,22 +95,24 @@ class RosNode extends EventEmitter {
 
   advertise(options) {
     let topic = options.topic;
-    let pub = this._publishers[topic];
-    if (!pub) {
-      pub = new Publisher(options, this);
-      this._publishers[topic] = pub;
+    let pubImpl = this._publishers[topic];
+    if (!pubImpl) {
+      pubImpl = new PublisherImpl(options, this);
+      this._publishers[topic] = pubImpl;
     }
-    return pub;
+
+    return new Publisher(pubImpl);
   }
 
   subscribe(options, callback) {
     let topic = options.topic;
-    let sub = this._subscribers[topic];
-    if (!sub) {
-      sub = new Subscriber(options, this);
-      this._subscribers[topic] = sub;
+    let subImpl = this._subscribers[topic];
+    if (!subImpl) {
+      subImpl = new SubscriberImpl(options, this);
+      this._subscribers[topic] = subImpl;
     }
 
+    const sub = new Subscriber(subImpl);
     if (callback && typeof callback === 'function') {
       sub.on('message', callback);
     }
@@ -134,8 +138,8 @@ class RosNode extends EventEmitter {
     const sub = this._subscribers[topic];
     if (sub) {
       this._debugLog.info('Unsubscribing from topic %s', topic);
-      sub.disconnect();
       delete this._subscribers[topic];
+      sub._shutdown();
       return this.unregisterSubscriber(topic);
     }
   }
@@ -144,8 +148,8 @@ class RosNode extends EventEmitter {
     const pub = this._publishers[topic];
     if (pub) {
       this._debugLog.info('Unadvertising topic %s', topic);
-      pub.disconnect();
       delete this._publishers[topic];
+      pub._shutdown();
       return this.unregisterPublisher(topic);
     }
   }
@@ -158,6 +162,18 @@ class RosNode extends EventEmitter {
       delete this._services[service];
       return this.unregisterService(service, server.getServiceUri());
     }
+  }
+
+  hasSubscriber(topic) {
+    return this._subscribers.hasOwnProperty(topic);
+  }
+
+  hasPublisher(topic) {
+    return this._publisheres.hasOwnProperty(topic);
+  }
+
+  hasService(service) {
+    return this._services.hasOwnProperty(service);
   }
 
   getNodeName() {

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -123,10 +123,13 @@ class RosNode extends EventEmitter {
   advertiseService(options, callback) {
     let service = options.service;
     let serv = this._services[service];
-    if (!serv) {
-      serv = new ServiceServer(options, callback, this);
-      this._services[service] = serv;
+    if (serv) {
+      this._log.warn('Tried to advertise a service that is already advertised in this node [%s]', service);
+      return;
     }
+    // else
+    serv = new ServiceServer(options, callback, this);
+    this._services[service] = serv;
     return serv;
   }
 
@@ -634,6 +637,8 @@ class RosNode extends EventEmitter {
 
       promises.push(shutdownServers());
       promises.push(clearXmlrpcQueues());
+
+      Logging.stopLogCleanup();
 
       process.removeListener('exit', exitHandler);
       process.removeListener('SIGINT', sigIntHandler);

--- a/src/lib/ServiceServer.js
+++ b/src/lib/ServiceServer.js
@@ -108,6 +108,10 @@ class ServiceServer extends EventEmitter {
   }
 
   handleClientConnection(client, header) {
+    if (this.isShutdown()) {
+      return;
+    }
+    // else
     // TODO: verify header data
     this._log.debug('Service %s handling new client connection ', this.getService());
 

--- a/src/lib/ServiceServer.js
+++ b/src/lib/ServiceServer.js
@@ -74,6 +74,10 @@ class ServiceServer extends EventEmitter {
     return NetworkUtils.formatServiceUri(this._port);
   }
 
+  getClientUris() {
+    return Object.keys(this._clients);
+  }
+
   /**
    * The ROS client shutdown code is a little noodly. Users can close a client through
    * the ROS node or the client itself and both are correct. Either through a node.unadvertise()

--- a/src/lib/Subscriber.js
+++ b/src/lib/Subscriber.js
@@ -64,7 +64,7 @@ class Subscriber extends EventEmitter {
   }
 
   /**
-   * Get the numbber of publishers currently connected to this subscriber
+   * Get the number of publishers currently connected to this subscriber
    * @returns {number}
    */
   getNumPublishers() {

--- a/src/lib/Subscriber.js
+++ b/src/lib/Subscriber.js
@@ -18,6 +18,7 @@
 "use strict";
 
 const EventEmitter = require('events');
+const Ultron = require('ultron');
 const {rebroadcast} = require('../utils/event_utils.js');
 
 //-----------------------------------------------------------------------
@@ -33,15 +34,16 @@ class Subscriber extends EventEmitter {
 
     ++impl.count;
     this._impl = impl;
+    this._ultron = new Ultron(impl);
 
     this._topic = impl.getTopic();
     this._type = impl.getType();
 
-    rebroadcast('registered', this._impl, this);
-    rebroadcast('connection', this._impl, this);
-    rebroadcast('disconnect', this._impl, this);
-    rebroadcast('error', this._impl, this);
-    rebroadcast('message', this._impl, this);
+    rebroadcast('registered', this._ultron, this);
+    rebroadcast('connection', this._ultron, this);
+    rebroadcast('disconnect', this._ultron, this);
+    rebroadcast('error', this._ultron, this);
+    rebroadcast('message', this._ultron, this);
   }
 
   /**
@@ -82,6 +84,8 @@ class Subscriber extends EventEmitter {
     if (this._impl) {
       const impl = this._impl
       this._impl = null;
+      this._ultron.destroy();
+      this._ultron = null;
 
       --impl.count;
       if (impl.count <= 0) {

--- a/src/lib/Subscriber.js
+++ b/src/lib/Subscriber.js
@@ -17,294 +17,66 @@
 
 "use strict";
 
-const NetworkUtils = require('../utils/network_utils.js');
-const SerializationUtils = require('../utils/serialization_utils.js');
-const DeserializeStream = SerializationUtils.DeserializeStream;
-const Deserialize =  SerializationUtils.Deserialize;
-const Serialize = SerializationUtils.Serialize;
-const TcprosUtils = require('../utils/tcpros_utils.js');
-const Socket = require('net').Socket;
 const EventEmitter = require('events');
-const Logging = require('./Logging.js');
-const {REGISTERING, REGISTERED, SHUTDOWN} = require('../utils/ClientStates.js');
-
-const protocols = [['TCPROS']];
+const {rebroadcast} = require('../utils/event_utils.js');
 
 //-----------------------------------------------------------------------
 
 class Subscriber extends EventEmitter {
-
-  constructor(options, nodeHandle) {
+  constructor(impl) {
     super();
 
-    this._topic = options.topic;
+    ++impl.count;
+    this._impl = impl;
 
-    this._type = options.type;
-
-    if (options.queueSize) {
-      this._queueSize = options.queueSize;
-    }
-    else {
-      this._queueSize = 1;
-    }
-
-    /**
-     * throttleMs interacts with queueSize to determine when to handle callbacks
-     *  < 0  : handle immediately - no interaction with queue
-     *  >= 0 : place event at end of event queue to handle after minimum delay (MS)
-     */
-    if (options.hasOwnProperty('throttleMs')) {
-      this._throttleMs = options.throttleMs;
-    }
-    else {
-      this._throttleMs = 0;
-    }
-
-    this._msgHandleTime = null;
-
-    this._nodeHandle = nodeHandle;
-    this._nodeHandle.getSpinner().addClient(this, this._getSpinnerId(), this._queueSize, this._throttleMs);
-
-    this._log = Logging.getLogger('ros.rosnodejs');
-
-    this._messageHandler = options.typeClass;
-
-    this._pubClients = {};
-
-    this._state = REGISTERING;
-    this._register();
-  }
-
-  _getSpinnerId() {
-    return `Subscriber://${this.getTopic()}`;
+    rebroadcast('registered', this._impl, this);
+    rebroadcast('connection', this._impl, this);
+    rebroadcast('disconnect', this._impl, this);
+    rebroadcast('error', this._impl, this);
+    rebroadcast('message', this._impl, this);
   }
 
   getTopic() {
-    return this._topic;
+    if (this._impl) {
+      return this._impl.getTopic();
+    }
+    // else
+    return null;
   }
 
   getType() {
-    return this._type;
+    if (this._impl) {
+      return this._impl.getType();
+    }
+    // else
+    return null;
   }
 
   getNumPublishers() {
-    return Object.keys(this._pubClients).length;
+    if (this._impl) {
+      return this._impl.getNumPublishers();
+    }
+    // else
+    return 0;
   }
 
   shutdown() {
-    this._log.debug('Shutting down subscriber %s', this.getTopic());
-    this._nodeHandle.unsubscribe(this.getTopic());
+    if (this._impl) {
+      const impl = this._impl
+      this._impl = null;
+      this.removeAllListeners();
+
+      --impl.count;
+      if (impl.count <= 0) {
+        return impl.shutdown();
+      }
+    }
+    // else
+    return Promise.resolve();
   }
 
   isShutdown() {
-    return this._state === SHUTDOWN;
-  }
-
-  /**
-   * Send a topic request to each of the publishers we haven't connected to yet
-   * @param pubs {Array} array of uris of nodes that are publishing this topic
-   */
-  requestTopicFromPubs(pubs) {
-    pubs.forEach((pubUri) => {
-      pubUri = pubUri.trim();
-      this._requestTopicFromPublisher(pubUri);
-    });
-  }
-
-  disconnect() {
-    this._state = SHUTDOWN;
-
-    Object.keys(this._pubClients).forEach(this._disconnectClient.bind(this));
-
-    // disconnect from the spinner in case we have any pending callbacks
-    this._nodeHandle.getSpinner().disconnect(this._getSpinnerId());
-    this._pubClients = {};
-  }
-
-  /**
-   * Handle an update from the ROS master with the list of current publishers. Connect to any new ones
-   * and disconnect from any not included in the list.
-   * @param publisherList [Array.string]
-   * @private
-   */
-  _handlePublisherUpdate(publisherList) {
-    const missingPublishers = new Set(Object.keys(this._pubClients));
-
-    publisherList.forEach((pubUri) => {
-      pubUri = pubUri.trim();
-      if (!this._pubClients.hasOwnProperty(pubUri)) {
-        this._requestTopicFromPublisher(pubUri);
-      }
-
-      missingPublishers.delete(pubUri);
-    });
-
-    missingPublishers.forEach((pubUri) => {
-      this._disconnectClient(pubUri);
-    });
-  }
-
-  _requestTopicFromPublisher(pubUri) {
-    let info = NetworkUtils.getAddressAndPortFromUri(pubUri);
-    // send a topic request to the publisher's node
-    this._log.debug('Sending topic request to ' + JSON.stringify(info));
-    this._nodeHandle.requestTopic(info.host, info.port, this._topic, protocols)
-      .then((resp) => {
-        this._handleTopicRequestResponse(resp, pubUri);
-      })
-      .catch((err, resp) => {
-        // there was an error in the topic request
-        this._log.warn('Error requesting topic on %s: %s, %s', this.getTopic(), err, resp);
-      });
-  }
-
-  _disconnectClient(clientId) {
-    const client = this._pubClients[clientId];
-    this._log.debug('Disconnecting client %s', clientId);
-    client.end();
-
-    client.$deserializer.removeAllListeners();
-
-    client.$deserializer.end();
-    client.unpipe(client.$deserializer);
-
-    delete client.$deserializer;
-    delete client.$boundMessageHandler;
-
-    delete this._pubClients[clientId];
-  }
-
-  _register() {
-    this._nodeHandle.registerSubscriber(this._topic, this._type)
-    .then((resp) => {
-      // if we were shutdown between the starting the registration and now, bail
-      if (this.isShutdown()) {
-        return;
-      }
-
-      // else handle response from register subscriber call
-      let code = resp[0];
-      let msg = resp[1];
-      let pubs = resp[2];
-      if ( code === 1 ) {
-        // success! update state to reflect that we're registered
-        this._state = REGISTERED;
-
-        if (pubs.length > 0) {
-          // this means we're ok and that publishers already exist on this topic
-          // we should connect to them
-          this.requestTopicFromPubs(pubs);
-        }
-        this.emit('registered');
-      }
-    })
-    .catch((err, resp) => {
-      this._log.warn('Error during subscriber %s registration: %s', this.getTopic(), err);
-    })
-  }
-
-  /**
-   * @param resp {Array} xmlrpc response to a topic request
-   */
-  _handleTopicRequestResponse(resp, nodeUri) {
-    if (this.isShutdown()) {
-      return;
-    }
-
-    this._log.debug('Topic request response: ' + JSON.stringify(resp));
-    let info = resp[2];
-    let port = info[2];
-    let address = info[1];
-    let client = new Socket();
-    client.name = address + ':' + port;
-    client.nodeUri = nodeUri;
-
-    client.on('end', () => {
-      this._log.info('Pub %s sent END', client.name, this.getTopic());
-    });
-    client.on('error', () => {
-      this._log.warn('Pub %s error on topic %s', client.name, this.getTopic());
-    });
-
-    client.connect(port, address, () => {
-      if (this.isShutdown()) {
-        client.end();
-        return;
-      }
-
-      this._log.debug('Subscriber on ' + this.getTopic() + ' connected to publisher at ' + address + ':' + port);
-      client.write(this._createTcprosHandshake());
-
-      this._pubClients[client.nodeUri] = client;
-    });
-
-
-    let deserializer = new DeserializeStream();
-
-    client.$boundMessageHandler = this._handleMessage.bind(this, client);
-    client.$deserializer = deserializer;
-
-    client.pipe(deserializer);
-    deserializer.on('message', client.$boundMessageHandler);
-  }
-
-  _createTcprosHandshake() {
-    return TcprosUtils.createSubHeader(this._nodeHandle.getNodeName(), this._messageHandler.md5sum(),
-                                       this.getTopic(), this.getType(), this._messageHandler.messageDefinition());
-  }
-
-  _handleMessage(client, msg) {
-    if (!client.$initialized) {
-
-      let header = TcprosUtils.parseTcpRosHeader(msg);
-      // check if the publisher had a problem with our connection header
-      if (header.error) {
-        this._log.error(header.error);
-        return;
-      }
-
-      // else validate publisher's header
-      const error = TcprosUtils.validatePubHeader(header, this.getType(), this._messageHandler.md5sum());
-      if (error) {
-        this._log.error(`Unable to validate subscriber ${this.getTopic()} connection header ${JSON.stringify(header)}`);
-        TcprosUtils.parsePubHeader(msg);
-        client.end(Serialize(error));
-        return;
-      }
-
-      this._log.debug('Subscriber ' + this.getTopic() + ' got connection header ' + JSON.stringify(header));
-      client.$initialized = true;
-
-      this.emit('connection', header, client.name);
-
-      client.on('close', () => {
-        this._log.info('Pub %s closed on topic %s', client.name, this.getTopic());
-        this._log.debug('Subscriber ' + this.getTopic() + ' client ' + client.name + ' disconnected!');
-        delete this._pubClients[client.nodeUri];
-
-        this.emit('disconnect')
-      });
-    }
-    else {
-      if (this._throttleMs < 0) {
-        this._handleMsgQueue([msg]);
-      }
-      else {
-        this._nodeHandle.getSpinner().ping(this._getSpinnerId(), msg);
-      }
-    }
-  }
-
-  _handleMsgQueue(msgQueue) {
-    try {
-      msgQueue.forEach((msg) => {
-        this.emit('message', this._messageHandler.deserialize(msg));
-      });
-    }
-    catch (err) {
-      this._log.error('Error while dispatching message on topic %s: %s', this.getTopic(), err);
-      this.emit('error', err);
-    }
+    return !!this._impl;
   }
 }
 

--- a/src/lib/impl/PublisherImpl.js
+++ b/src/lib/impl/PublisherImpl.js
@@ -268,7 +268,7 @@ class PublisherImpl extends EventEmitter {
 
     // if this publisher had the tcpNoDelay option set
     // disable the nagle algorithm
-    if  (this._tcpNoDelay) {
+    if  (this._tcpNoDelay || header.tcp_nodelay === 1) {
       subscriber.setNoDelay(true);
     }
 

--- a/src/lib/impl/PublisherImpl.js
+++ b/src/lib/impl/PublisherImpl.js
@@ -1,0 +1,271 @@
+/*
+ *    Copyright 2016 Rethink Robotics
+ *
+ *    Copyright 2016 Chris Smith
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing,
+ *    software distributed under the License is distributed on an "AS
+ *    IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ */
+
+"use strict";
+
+const SerializationUtils = require('../../utils/serialization_utils.js');
+const Serialize = SerializationUtils.Serialize;
+const TcprosUtils = require('../../utils/tcpros_utils.js');
+const EventEmitter = require('events');
+const Logging = require('../Logging.js');
+const {REGISTERING, REGISTERED, SHUTDOWN} = require('../../utils/ClientStates.js');
+
+class PublisherImpl extends EventEmitter {
+  constructor(options, nodeHandle) {
+    super();
+
+    this.count = 0;
+
+    this._topic = options.topic;
+
+    this._type = options.type;
+
+    this._latching = !!options.latching;
+
+    this._tcpNoDelay =  !!options.tcpNoDelay;
+
+
+    if (options.queueSize) {
+      this._queueSize = options.queueSize;
+    }
+    else {
+      this._queueSize = 1;
+    }
+
+    /**
+     * throttleMs interacts with queueSize to determine when to send
+     * messages.
+     *  < 0  : send immediately - no interaction with queue
+     * >= 0 : place event at end of event queue to publish message
+         after minimum delay (MS)
+     */
+    if (options.hasOwnProperty('throttleMs')) {
+      this._throttleMs = options.throttleMs;
+    }
+    else {
+      this._throttleMs = 0;
+    }
+
+    // OPTIONS STILL NOT HANDLED:
+    //  headers: extra headers to include
+    //  subscriber_listener: callback for new subscribers connect/disconnect
+
+    this._resolve = !!options.resolve;
+
+    this._lastSentMsg = null;
+
+    this._nodeHandle = nodeHandle;
+    this._nodeHandle.getSpinner().addClient(this, this._getSpinnerId(), this._queueSize, this._throttleMs);
+
+    this._log = Logging.getLogger('ros.rosnodejs');
+
+    this._subClients = {};
+
+    this._messageHandler = options.typeClass;
+
+    this._state = REGISTERING;
+    this._register();
+  }
+
+  _getSpinnerId() {
+    return `Publisher://${this.getTopic()}`;
+  }
+
+  getTopic() {
+    return this._topic;
+  }
+
+  getType() {
+    return this._type;
+  }
+
+  getLatching() {
+    return this._latching;
+  }
+
+  getNumSubscribers() {
+    return Object.keys(this._subClients).length;
+  }
+
+  shutdown() {
+    return this._nodeHandle.unadvertise(this.getTopic());
+  }
+
+  _shutdown() {
+    this._state = SHUTDOWN;
+    this._log.debug('Shutting down publisher %s', this.getTopic());
+
+    Object.keys(this._subClients).forEach((clientId) => {
+      const client = this._subClients[clientId];
+      client.end();
+    });
+
+    // disconnect from the spinner in case we have any pending callbacks
+    this._nodeHandle.getSpinner().disconnect(this._getSpinnerId());
+    this._subClients = {};
+  }
+
+  isShutdown() {
+    return this._state === SHUTDOWN;
+  }
+
+  /**
+   * Schedule the msg for publishing - or publish immediately if we're
+   * supposed to
+   * @param msg {object} object type matching this._type
+   * @param [throttleMs] {number} optional override for publisher setting
+   */
+  publish(msg, throttleMs) {
+    if (this.isShutdown()) {
+      return;
+    }
+
+    if (typeof throttleMs !== 'number') {
+      throttleMs = this._throttleMs;
+    }
+
+    if (throttleMs < 0) {
+      // short circuit JS event queue, publish "synchronously"
+      this._handleMsgQueue([msg]);
+    }
+    else {
+      this._nodeHandle.getSpinner().ping(this._getSpinnerId(), msg);
+    }
+  }
+
+  /**
+   * Pulls all msgs off queue, serializes, and publishes them
+   */
+  _handleMsgQueue(msgQueue) {
+
+    // There's a small chance that we were shutdown while the spinner was locked
+    // which could cause _handleMsgQueue to be called if this publisher was in there.
+    if (this.isShutdown()) {
+      return;
+    }
+
+    const numClients = this.getNumSubscribers();
+    if (numClients === 0) {
+      this._log.debugThrottle(2000, `Publishing message on ${this.getTopic()} with no subscribers`);
+    }
+
+    try {
+      msgQueue.forEach((msg) => {
+        if (this._resolve) {
+          msg = this._messageHandler.Resolve(msg);
+        }
+
+        const serializedMsg = TcprosUtils.serializeMessage(this._messageHandler, msg);
+
+        Object.keys(this._subClients).forEach((client) => {
+          this._subClients[client].write(serializedMsg);
+        });
+
+        // if this publisher is supposed to latch,
+        // save the last message. Any subscribers that connect
+        // before another call to publish() will receive this message
+        if (this.getLatching()) {
+          this._lastSentMsg = serializedMsg;
+        }
+      });
+    }
+    catch (err) {
+      this._log.error('Error when publishing message on topic %s: %s', this.getTopic(), err.stack);
+      this.emit('error', err);
+    }
+  }
+
+  handleSubscriberConnection(subscriber, header) {
+    let error = TcprosUtils.validateSubHeader(
+      header, this.getTopic(), this.getType(),
+      this._messageHandler.md5sum());
+    if (error !== null) {
+      this._log.error('Unable to validate subscriber connection header '
+                      + JSON.stringify(header));
+      subscriber.end(Serialize(error));
+      return;
+    }
+    // else
+    this._log.info('Pub %s got connection header %s', this.getTopic(), JSON.stringify(header));
+
+    // create and send response
+    let respHeader =
+      TcprosUtils.createPubHeader(
+        this._nodeHandle.getNodeName(),
+        this._messageHandler.md5sum(),
+        this.getType(),
+        this.getLatching(),
+        this._messageHandler.messageDefinition());
+    subscriber.write(respHeader);
+
+    // if this publisher had the tcpNoDelay option set
+    // disable the nagle algorithm
+    if  (this._tcpNoDelay) {
+      subscriber.setNoDelay(true);
+    }
+
+    subscriber.on('close', () => {
+      this._log.info('Publisher %s client %s disconnected!',
+                      this.getTopic(), subscriber.name);
+      delete this._subClients[subscriber.name];
+      this.emit('disconnect');
+    });
+
+    subscriber.on('end', () => {
+      this._log.info('Sub %s sent END', subscriber.name);
+    });
+
+    subscriber.on('error', () => {
+      this._log.warn('Sub %s had error', subscriber.name);
+    });
+
+    if (this._lastSentMsg !== null) {
+      this._log.debug('Sending latched msg to new subscriber');
+      subscriber.write(this._lastSentMsg);
+    }
+
+    // if handshake good, add to list, we'll start publishing to it
+    this._subClients[subscriber.name] = subscriber;
+
+    this.emit('connection', header, subscriber.name);
+  }
+
+  _register() {
+    this._nodeHandle.registerPublisher(this._topic, this._type)
+    .then((resp) => {
+      // if we were shutdown between the starting the registration and now, bail
+      if (this.isShutdown()) {
+        return;
+      }
+
+      this._log.info('Registered %s as a publisher: %j', this._topic, resp);
+      let code = resp[0];
+      let msg = resp[1];
+      let subs = resp[2];
+      if (code === 1) {
+        // registration worked
+        this._state = REGISTERED;
+        this.emit('registered');
+      }
+    })
+    .catch((err) => {
+      this._log.error('Error while registering publisher %s: %s', this.getTopic(), err);
+    })
+  }
+}
+
+module.exports = PublisherImpl;

--- a/src/lib/impl/PublisherImpl.js
+++ b/src/lib/impl/PublisherImpl.js
@@ -1,7 +1,7 @@
 /*
- *    Copyright 2016 Rethink Robotics
+ *    Copyright 2017 Rethink Robotics
  *
- *    Copyright 2016 Chris Smith
+ *    Copyright 2017 Chris Smith
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/lib/impl/SubscriberImpl.js
+++ b/src/lib/impl/SubscriberImpl.js
@@ -1,0 +1,319 @@
+/*
+ *    Copyright 2016 Rethink Robotics
+ *
+ *    Copyright 2016 Chris Smith
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+"use strict";
+
+const NetworkUtils = require('../../utils/network_utils.js');
+const SerializationUtils = require('../../utils/serialization_utils.js');
+const DeserializeStream = SerializationUtils.DeserializeStream;
+const Deserialize =  SerializationUtils.Deserialize;
+const Serialize = SerializationUtils.Serialize;
+const TcprosUtils = require('../../utils/tcpros_utils.js');
+const Socket = require('net').Socket;
+const EventEmitter = require('events');
+const Logging = require('../Logging.js');
+const {REGISTERING, REGISTERED, SHUTDOWN} = require('../../utils/ClientStates.js');
+
+const protocols = [['TCPROS']];
+
+//-----------------------------------------------------------------------
+
+class SubscriberImpl extends EventEmitter {
+
+  constructor(options, nodeHandle) {
+    super();
+
+    this.count = 0;
+
+    this._topic = options.topic;
+
+    this._type = options.type;
+
+    if (options.queueSize) {
+      this._queueSize = options.queueSize;
+    }
+    else {
+      this._queueSize = 1;
+    }
+
+    /**
+     * throttleMs interacts with queueSize to determine when to handle callbacks
+     *  < 0  : handle immediately - no interaction with queue
+     *  >= 0 : place event at end of event queue to handle after minimum delay (MS)
+     */
+    if (options.hasOwnProperty('throttleMs')) {
+      this._throttleMs = options.throttleMs;
+    }
+    else {
+      this._throttleMs = 0;
+    }
+
+    this._msgHandleTime = null;
+
+    this._nodeHandle = nodeHandle;
+    this._nodeHandle.getSpinner().addClient(this, this._getSpinnerId(), this._queueSize, this._throttleMs);
+
+    this._log = Logging.getLogger('ros.rosnodejs');
+
+    this._messageHandler = options.typeClass;
+
+    this._pubClients = {};
+
+    this._state = REGISTERING;
+    this._register();
+  }
+
+  _getSpinnerId() {
+    return `Subscriber://${this.getTopic()}`;
+  }
+
+  getTopic() {
+    return this._topic;
+  }
+
+  getType() {
+    return this._type;
+  }
+
+  getNumPublishers() {
+    return Object.keys(this._pubClients).length;
+  }
+
+  shutdown() {
+    return this._nodeHandle.unsubscribe(this.getTopic());
+  }
+
+  _shutdown() {
+    this._state = SHUTDOWN;
+    this._log.debug('Shutting down subscriber %s', this.getTopic());
+
+    Object.keys(this._pubClients).forEach(this._disconnectClient.bind(this));
+
+    // disconnect from the spinner in case we have any pending callbacks
+    this._nodeHandle.getSpinner().disconnect(this._getSpinnerId());
+    this._pubClients = {};
+  }
+
+  isShutdown() {
+    return this._state === SHUTDOWN;
+  }
+
+  /**
+   * Send a topic request to each of the publishers we haven't connected to yet
+   * @param pubs {Array} array of uris of nodes that are publishing this topic
+   */
+  requestTopicFromPubs(pubs) {
+    pubs.forEach((pubUri) => {
+      pubUri = pubUri.trim();
+      this._requestTopicFromPublisher(pubUri);
+    });
+  }
+
+  disconnect() {
+
+  }
+
+  /**
+   * Handle an update from the ROS master with the list of current publishers. Connect to any new ones
+   * and disconnect from any not included in the list.
+   * @param publisherList [Array.string]
+   * @private
+   */
+  _handlePublisherUpdate(publisherList) {
+    const missingPublishers = new Set(Object.keys(this._pubClients));
+
+    publisherList.forEach((pubUri) => {
+      pubUri = pubUri.trim();
+      if (!this._pubClients.hasOwnProperty(pubUri)) {
+        this._requestTopicFromPublisher(pubUri);
+      }
+
+      missingPublishers.delete(pubUri);
+    });
+
+    missingPublishers.forEach((pubUri) => {
+      this._disconnectClient(pubUri);
+    });
+  }
+
+  _requestTopicFromPublisher(pubUri) {
+    let info = NetworkUtils.getAddressAndPortFromUri(pubUri);
+    // send a topic request to the publisher's node
+    this._log.debug('Sending topic request to ' + JSON.stringify(info));
+    this._nodeHandle.requestTopic(info.host, info.port, this._topic, protocols)
+      .then((resp) => {
+        this._handleTopicRequestResponse(resp, pubUri);
+      })
+      .catch((err, resp) => {
+        // there was an error in the topic request
+        this._log.warn('Error requesting topic on %s: %s, %s', this.getTopic(), err, resp);
+      });
+  }
+
+  _disconnectClient(clientId) {
+    const client = this._pubClients[clientId];
+    this._log.debug('Disconnecting client %s', clientId);
+    client.end();
+
+    client.$deserializer.removeAllListeners();
+
+    client.$deserializer.end();
+    client.unpipe(client.$deserializer);
+
+    delete client.$deserializer;
+    delete client.$boundMessageHandler;
+
+    delete this._pubClients[clientId];
+  }
+
+  _register() {
+    this._nodeHandle.registerSubscriber(this._topic, this._type)
+    .then((resp) => {
+      // if we were shutdown between the starting the registration and now, bail
+      if (this.isShutdown()) {
+        return;
+      }
+
+      // else handle response from register subscriber call
+      let code = resp[0];
+      let msg = resp[1];
+      let pubs = resp[2];
+      if ( code === 1 ) {
+        // success! update state to reflect that we're registered
+        this._state = REGISTERED;
+
+        if (pubs.length > 0) {
+          // this means we're ok and that publishers already exist on this topic
+          // we should connect to them
+          this.requestTopicFromPubs(pubs);
+        }
+        this.emit('registered');
+      }
+    })
+    .catch((err, resp) => {
+      this._log.warn('Error during subscriber %s registration: %s', this.getTopic(), err);
+    })
+  }
+
+  /**
+   * @param resp {Array} xmlrpc response to a topic request
+   */
+  _handleTopicRequestResponse(resp, nodeUri) {
+    if (this.isShutdown()) {
+      return;
+    }
+
+    this._log.debug('Topic request response: ' + JSON.stringify(resp));
+    let info = resp[2];
+    let port = info[2];
+    let address = info[1];
+    let client = new Socket();
+    client.name = address + ':' + port;
+    client.nodeUri = nodeUri;
+
+    client.on('end', () => {
+      this._log.info('Pub %s sent END', client.name, this.getTopic());
+    });
+    client.on('error', () => {
+      this._log.warn('Pub %s error on topic %s', client.name, this.getTopic());
+    });
+
+    client.connect(port, address, () => {
+      if (this.isShutdown()) {
+        client.end();
+        return;
+      }
+
+      this._log.debug('Subscriber on ' + this.getTopic() + ' connected to publisher at ' + address + ':' + port);
+      client.write(this._createTcprosHandshake());
+
+      this._pubClients[client.nodeUri] = client;
+    });
+
+
+    let deserializer = new DeserializeStream();
+
+    client.$boundMessageHandler = this._handleMessage.bind(this, client);
+    client.$deserializer = deserializer;
+
+    client.pipe(deserializer);
+    deserializer.on('message', client.$boundMessageHandler);
+  }
+
+  _createTcprosHandshake() {
+    return TcprosUtils.createSubHeader(this._nodeHandle.getNodeName(), this._messageHandler.md5sum(),
+                                       this.getTopic(), this.getType(), this._messageHandler.messageDefinition());
+  }
+
+  _handleMessage(client, msg) {
+    if (!client.$initialized) {
+
+      let header = TcprosUtils.parseTcpRosHeader(msg);
+      // check if the publisher had a problem with our connection header
+      if (header.error) {
+        this._log.error(header.error);
+        return;
+      }
+
+      // else validate publisher's header
+      const error = TcprosUtils.validatePubHeader(header, this.getType(), this._messageHandler.md5sum());
+      if (error) {
+        this._log.error(`Unable to validate subscriber ${this.getTopic()} connection header ${JSON.stringify(header)}`);
+        TcprosUtils.parsePubHeader(msg);
+        client.end(Serialize(error));
+        return;
+      }
+
+      this._log.debug('Subscriber ' + this.getTopic() + ' got connection header ' + JSON.stringify(header));
+      client.$initialized = true;
+
+      this.emit('connection', header, client.name);
+
+      client.on('close', () => {
+        this._log.info('Pub %s closed on topic %s', client.name, this.getTopic());
+        this._log.debug('Subscriber ' + this.getTopic() + ' client ' + client.name + ' disconnected!');
+        delete this._pubClients[client.nodeUri];
+
+        this.emit('disconnect')
+      });
+    }
+    else {
+      if (this._throttleMs < 0) {
+        this._handleMsgQueue([msg]);
+      }
+      else {
+        this._nodeHandle.getSpinner().ping(this._getSpinnerId(), msg);
+      }
+    }
+  }
+
+  _handleMsgQueue(msgQueue) {
+    try {
+      msgQueue.forEach((msg) => {
+        this.emit('message', this._messageHandler.deserialize(msg));
+      });
+    }
+    catch (err) {
+      this._log.error('Error while dispatching message on topic %s: %s', this.getTopic(), err);
+      this.emit('error', err);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------
+
+module.exports = SubscriberImpl;

--- a/src/lib/impl/SubscriberImpl.js
+++ b/src/lib/impl/SubscriberImpl.js
@@ -1,7 +1,7 @@
 /*
- *    Copyright 2016 Rethink Robotics
+ *    Copyright 2017 Rethink Robotics
  *
- *    Copyright 2016 Chris Smith
+ *    Copyright 2017 Chris Smith
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/utils/event_utils.js
+++ b/src/utils/event_utils.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rebroadcast(evt, emitter, rebroadcaster) {
+    emitter.on(evt, rebroadcaster.emit.bind(rebroadcaster, evt));
+  }
+};

--- a/src/utils/tcpros_utils.js
+++ b/src/utils/tcpros_utils.js
@@ -143,7 +143,7 @@ let TcprosUtils = {
     let info = {};
     const fields = deserializeStringFields(header);
     fields.forEach((field) => {
-      
+
       if (field.startsWith(md5Prefix)) {
         info.md5sum = field.substr(md5Prefix.length);
       }
@@ -164,7 +164,7 @@ let TcprosUtils = {
     let info = {};
     const fields = deserializeStringFields(header);
     fields.forEach((field) => {
-      
+
       if (field.startsWith(md5Prefix)) {
         info.md5sum = field.substr(md5Prefix.length);
       }
@@ -206,7 +206,7 @@ let TcprosUtils = {
     let info = {};
     const fields = deserializeStringFields(header);
     fields.forEach((field) => {
-      
+
       if (field.startsWith(md5Prefix)) {
         info.md5sum = field.substr(md5Prefix.length);
       }

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -565,6 +565,101 @@ describe('Protocol Test', () => {
       // if we haven't received a message by now we should be good
       setTimeout(done, 500);
     });
+
+    it('2 Publishers on Same Topic', function(done) {
+      this.slow(2000);
+      const nh = rosnodejs.nh;
+
+      let msg1;
+      const sub = nh.subscribe(topic, msgType, (msg) => {
+          msg1 = msg.data;
+      });
+
+      const pub1 = nh.advertise(topic, msgType, {latching: true});
+      const pub2 = nh.advertise(topic, msgType, {latching: true});
+
+      expect(pub1).to.not.equal(pub2);
+
+      pub1.publish({data: 1});
+
+      sub.once('message', ({data}) => {
+        expect(sub.getNumPublishers()).to.equal(1);
+        expect(data).to.equal(1);
+
+        pub2.publish({data: 2});
+        sub.once('message', ({data}) => {
+          expect(data).to.equal(2);
+
+          pub1.shutdown()
+          .then(() => {
+            expect(sub.getNumPublishers()).to.equal(1);
+
+            pub2.publish({data: 3});
+
+            sub.once('message', ({data}) => {
+              expect(data).to.equal(3);
+
+              pub2.shutdown()
+              .then(() =>  {
+                expect(sub.getNumPublishers()).to.equal(0);
+                done();
+              });
+            });
+          })
+        });
+      })
+    });
+
+    it('2 Subscribers on Same Topic', function(done) {
+      this.slow(2000);
+      const nh = rosnodejs.nh;
+
+      let msg1;
+      const sub1 = nh.subscribe(topic, msgType, (msg) => {
+          msg1 = msg.data;
+      });
+
+      let msg2;
+      const sub2 = nh.subscribe(topic, msgType, (msg) => {
+        msg2 = msg.data;
+      });
+
+      expect(sub1).to.not.equal(msg2);
+
+      const pub = nh.advertise(topic, msgType, {latching: true});
+
+      pub.publish({data: 1});
+
+      sub2.once('message', () => {
+        expect(pub.getNumSubscribers()).to.equal(1);
+
+        expect(msg1).to.equal(msg2);
+        pub.publish({data: 25});
+
+        sub2.once('message', () => {
+          expect(msg1).to.equal(msg2);
+          msg1 = null;
+          msg2 = null;
+
+          sub1.shutdown()
+          .then(() => {
+            pub.publish({data: 30});
+
+            sub2.once('message', () => {
+              expect(msg1).to.equal(null);
+              expect(msg2).to.equal(30);
+              expect(pub.getNumSubscribers()).to.equal(1);
+
+              sub2.shutdown()
+              .then(() => {
+                expect(pub.getNumSubscribers()).to.equal(0);
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('Service', () => {

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -579,6 +579,8 @@ describe('Protocol Test', () => {
       const pub2 = nh.advertise(topic, msgType, {latching: true});
 
       expect(pub1).to.not.equal(pub2);
+      expect(pub1._impl.listenerCount('connection')).to.equal(2);
+      expect(pub2._impl.listenerCount('connection')).to.equal(2);
 
       pub1.publish({data: 1});
 
@@ -592,6 +594,9 @@ describe('Protocol Test', () => {
 
           pub1.shutdown()
           .then(() => {
+            expect(pub1._impl).to.equal(null);
+            expect(pub2._impl.listenerCount('connection')).to.equal(1);
+
             expect(sub.getNumPublishers()).to.equal(1);
 
             pub2.publish({data: 3});
@@ -602,6 +607,7 @@ describe('Protocol Test', () => {
               pub2.shutdown()
               .then(() =>  {
                 expect(sub.getNumPublishers()).to.equal(0);
+                expect(pub2._impl).to.equal(null);
                 done();
               });
             });
@@ -624,7 +630,9 @@ describe('Protocol Test', () => {
         msg2 = msg.data;
       });
 
-      expect(sub1).to.not.equal(msg2);
+      expect(sub1).to.not.equal(sub2);
+      expect(sub1._impl.listenerCount('connection')).to.equal(2);
+      expect(sub2._impl.listenerCount('connection')).to.equal(2);
 
       const pub = nh.advertise(topic, msgType, {latching: true});
 
@@ -643,6 +651,8 @@ describe('Protocol Test', () => {
 
           sub1.shutdown()
           .then(() => {
+            expect(sub1._impl).to.equal(null);
+            expect(sub2._impl.listenerCount('connection')).to.equal(1);
             pub.publish({data: 30});
 
             sub2.once('message', () => {
@@ -652,6 +662,7 @@ describe('Protocol Test', () => {
 
               sub2.shutdown()
               .then(() => {
+                expect(sub2._impl).to.equal(null);
                 expect(pub.getNumSubscribers()).to.equal(0);
                 done();
               });

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const rosnodejs = require('../src/index.js');
 const Subscriber = require('../src/lib/Subscriber.js');
+const SubscriberImpl = require('../src/lib/impl/SubscriberImpl.js');
 const xmlrpc = require('xmlrpc');
 const netUtils = require('../src/utils/network_utils.js');
 
@@ -72,7 +73,6 @@ describe('Protocol Test', () => {
 
         const resp = [ 1, 'registered!', [] ];
         callback(null, resp);
-        done();
       });
 
       const nh = rosnodejs.nh;
@@ -80,6 +80,10 @@ describe('Protocol Test', () => {
         (data) => {},
         { queueSize: 1, throttleMs: 1000 }
       );
+
+      sub.on('registered', () => {
+        done();
+      })
     });
 
     it('unregisterSubscriber', (done) => {
@@ -492,11 +496,14 @@ describe('Protocol Test', () => {
       this.slow(1600);
       const nh = rosnodejs.nh;
       // manually construct a subscriber...
-      const sub = new Subscriber({
-        topic,
-        type: 'std_msgs/String',
-        typeClass: rosnodejs.require('std_msgs').msg.String
-      },nh._node);
+      const subImpl = new SubscriberImpl({
+          topic,
+          type: 'std_msgs/String',
+          typeClass: rosnodejs.require('std_msgs').msg.String
+        },
+        nh._node);
+
+      const sub = new Subscriber(subImpl);
 
       const SOCKET_CONNECT_CACHED = net.Socket.prototype.connect;
       const SOCKET_END_CACHED = net.Socket.prototype.end;
@@ -745,4 +752,3 @@ describe('Protocol Test', () => {
     });
   });
 });
-


### PR DESCRIPTION
- Allows multiple independent publishers/subscribers on the same topic so shutting down one will not shut down the others.
- Adds support for the `getBusInfo` XMLRPC call (this is what `rosnode info` uses)
- Adds partial support for a maximum number of XMLRPC calls before failure. Expanding this will let users
  attempt to connect to a ROS master and handle the failure cleanly on their end if there isn't one there.
- No longer supports multiple calls to `advertiseService` (mirroring `roscpp`)

`PublisherImpl` and `SubscriberImpl` are essentially moves of the previous Publisher, Subscriber code.