### PR TITLE
Support non-spec message dividers 

### DIFF
--- a/test/gennodejsTest.js
+++ b/test/gennodejsTest.js
@@ -735,6 +735,20 @@ describe('gennodejsTests', () => {
 
       done();
     });
+
+    it('Service with improper divider', (done) => {
+      // correct message divider is '---'
+      // we're allowing any line starting with '---' though, parroting genmsg
+      const HeaderService = msgUtils.getHandlerForSrvType('test_msgs/NonSpecServiceDivider');
+
+      const requestMsg = HeaderService.Request.messageDefinition().trim();
+      expect(requestMsg).to.equal('string data');
+
+      const responseMsg = HeaderService.Response.messageDefinition().trim();
+      expect(responseMsg).to.equal('uint8 response');
+
+      done();
+    });
   });
 
   describe('actions', () => {

--- a/test/onTheFlyMessages.js
+++ b/test/onTheFlyMessages.js
@@ -740,6 +740,20 @@ describe('On The Fly Message Tests', () => {
 
       done();
     });
+
+    it('Service with improper divider', (done) => {
+      // correct message divider is '---'
+      // we're allowing any line starting with '---' though, parroting genmsg
+      const HeaderService = msgUtils.getHandlerForSrvType('test_msgs/NonSpecServiceDivider');
+
+      const requestMsg = HeaderService.Request.messageDefinition().trim();
+      expect(requestMsg).to.equal('string data');
+
+      const responseMsg = HeaderService.Response.messageDefinition().trim();
+      expect(responseMsg).to.equal('uint8 response');
+
+      done();
+    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
Although the ROS service [spec](http://wiki.ros.org/srv#Service_Description_Specification) uses '---' as the delimiter between request and response sections of the message, the parsing in [`genmsg`](https://github.com/ros/genmsg/blob/indigo-devel/src/genmsg/msg_loader.py#L459) leniently considers any line starting with '---' to be a valid delimiter. We now support this too.

Also includes a small optimization to only parse action and service files once for the relevant sections (request, response, goal, feedback, result).

Adds a small test for services. Depends on a pull request on [test_msgs](https://github.com/RethinkRobotics-opensource/test_msgs/pull/1)