### PR TITLE
Fixes a typo in on-the-fly message generation code

### DIFF
--- a/src/utils/messageGeneration/messages.js
+++ b/src/utils/messageGeneration/messages.js
@@ -181,7 +181,7 @@ function buildMessageFromSpec(msgSpec) {
         Request,
         Response,
         md5sum: () => { return md5Sum; },
-        dataType: () => { return fullMsg; }
+        datatype: () => { return fullMsg; }
       };
       setMessageInRegistry(fullMsg, service, type);
       break;


### PR DESCRIPTION
Small but catastrophic.

Without it, the initNode fails with
```
[ERROR] [1503360005.360] (ros.rosnodejs): Exception trying to advertise service /app/get_loggers
```