### PR TITLE
Adds support for shutting down action clients

### DIFF
--- a/src/lib/ActionClient.js
+++ b/src/lib/ActionClient.js
@@ -139,13 +139,22 @@ class ActionClient extends EventEmitter {
     return id;
   }
 
+  /**
+   * Shuts down this ActionClient. It shuts down publishers, subscriptions
+   * and removes all attached event listeners.
+   * @returns {Promise}
+   */
+
   shutdown() {
     this.removeAllListeners();
-    this._goalPub.shutdown();
-    this._cancelPub.shutdown();
-    this._statusSub.shutdown();
-    this._feedbackSub.shutdown();
-    this._resultSub.shutdown();
+
+    return Promise.all([
+      this._goalPub.shutdown(),
+      this._cancelPub.shutdown(),
+      this._statusSub.shutdown(),
+      this._feedbackSub.shutdown(),
+      this._resultSub.shutdown()
+    ]);
   }
 }
 

--- a/src/lib/ActionClient.js
+++ b/src/lib/ActionClient.js
@@ -138,6 +138,15 @@ class ActionClient extends EventEmitter {
     });
     return id;
   }
+
+  shutdown() {
+    this.removeAllListeners();
+    this._goalPub.shutdown();
+    this._cancelPub.shutdown();
+    this._statusSub.shutdown();
+    this._feedbackSub.shutdown();
+    this._resultSub.shutdown();
+  }
 }
 
 module.exports = ActionClient;


### PR DESCRIPTION
I know ActionClients normally are long-lived objects, but I needed to create & destroy them with certain frequency, and that lead to a warning message from EventEmitter:

```
W20170919-11:11:57.897(-3)? (STDERR) Trace
W20170919-11:11:57.897(-3)? (STDERR)     at SubscriberImpl.addListener (events.js:239:17)
W20170919-11:11:57.897(-3)? (STDERR)     at Ultron.on (/app/node_modules/ultron/index.js:42:11)
W20170919-11:11:57.897(-3)? (STDERR)     at rebroadcast (/app/node_modules/rosnodejs/dist/utils/event_utils.js:5:13)
W20170919-11:11:57.898(-3)? (STDERR)     at new Subscriber (/app/node_modules/rosnodejs/dist/lib/Subscriber.js:60:5)
W20170919-11:11:57.898(-3)? (STDERR)     at RosNode.subscribe (/app/node_modules/rosnodejs/dist/lib/RosNode.js:137:17)
W20170919-11:11:57.898(-3)? (STDERR)     at NodeHandle.subscribe (/app/node_modules/rosnodejs/dist/lib/NodeHandle.js:131:27)
W20170919-11:11:57.898(-3)? (STDERR)     at new ActionClient (/app/node_modules/rosnodejs/dist/lib/ActionClient.js:73:27)
W20170919-11:11:57.898(-3)? (STDERR)     at NodeHandle.actionClient (/app/node_modules/rosnodejs/dist/lib/NodeHandle.js:226:14)
W20170919-11:11:57.898(-3)? (STDERR)     at MyActionClient.run (imports/ros/my-action-client.js:170:30)
W20170919-11:11:57.899(-3)? (STDERR) (node) warning: possible EventEmitter memory leak detected. 11 error listeners added. Use emitter.setMaxListeners() to increase limit.
W20170919-11:11:57.899(-3)? (STDERR) Trace
```

This PR adds a shutdown method to the action client that cancels subscribers & publishers as well as removing attached listeners.
