### PR TITLE
Fix bug with hasParam and getParamNames.

### DIFF
--- a/src/lib/ParamServerApiClient.js
+++ b/src/lib/ParamServerApiClient.js
@@ -88,15 +88,14 @@ class ParamServerApiClient {
     ];
 
     return new Promise((resolve, reject) => {
-      this._xmlrpcClient.methodCall('hasParam', data, (err, resp) => {
-        if (err || resp[0] !== 1) {
-          reject(err, resp);
-        }
-        else {
+      this._call('hasParam', data, (resp) => {
+        if (resp[0] !== 1) {
+          reject(resp);
+        } else {
           // resp[2] is whether it actually has param and presumably all anyone  cares about
           resolve(resp[2]);
         }
-      });
+      }, reject);
     });
   }
 
@@ -106,15 +105,14 @@ class ParamServerApiClient {
     ];
 
     return new Promise((resolve, reject) => {
-      this._xmlrpcClient.methodCall('getParamNames', data, (err, resp) => {
-        if (err || resp[0] !== 1) {
-          reject(err, resp);
-        }
-        else {
+      this._call('getParamNames', data, (resp) => {
+        if (resp[0] !== 1) {
+          reject(resp);
+        } else {
           // resp[2] is parameter name list and presumably all anyone cares about
           resolve(resp[2]);
         }
-      });
+      }, reject);
     });
   }
 }

--- a/src/lib/ParamServerApiClient.js
+++ b/src/lib/ParamServerApiClient.js
@@ -89,12 +89,8 @@ class ParamServerApiClient {
 
     return new Promise((resolve, reject) => {
       this._call('hasParam', data, (resp) => {
-        if (resp[0] !== 1) {
-          reject(resp);
-        } else {
-          // resp[2] is whether it actually has param and presumably all anyone  cares about
-          resolve(resp[2]);
-        }
+        // resp[2] is whether it actually has param and presumably all anyone  cares about
+        resolve(resp[2]);
       }, reject);
     });
   }
@@ -106,12 +102,8 @@ class ParamServerApiClient {
 
     return new Promise((resolve, reject) => {
       this._call('getParamNames', data, (resp) => {
-        if (resp[0] !== 1) {
-          reject(resp);
-        } else {
-          // resp[2] is parameter name list and presumably all anyone cares about
-          resolve(resp[2]);
-        }
+        // resp[2] is parameter name list and presumably all anyone cares about
+        resolve(resp[2]);
       }, reject);
     });
   }


### PR DESCRIPTION
I was trying to use [`hasParam`](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/lib/RosNode.js#L319) in my program, but I got the following error:

`[TypeError: _this4._xmlrpcClient.methodCall is not a function
    at /home/.../node_modules/rosnodejs/dist/lib/ParamServerApiClient.js:102:30
    at Promise (<anonymous>)
    at ParamServerApiClient.hasParam (/home/.../node_modules/rosnodejs/dist/lib/ParamServerApiClient.js:101:14)
    at RosNode.hasParam (/home/.../node_modules/rosnodejs/dist/lib/RosNode.js:342:35)
    at NodeHandle.hasParam (/home/.../node_modules/rosnodejs/dist/lib/NodeHandle.js:334:25)
    at fetchParams (/home/.../scripts/test_server.js:14:34)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)]`

I found that the bug was related to the indirection involving the `XmlrpcClient` wrapper in rosnodejs and the `xmlrpc` module that it uses:

`XmlrpcClient` seems to be a wrapper around `xmlrpc`: it has a [`_xmlrpcClient` property](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/utils/XmlrpcClient.js#L44), which is an object from `xmlrpc`, and a [`call()` function](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/utils/XmlrpcClient.js#L60), which is the main interface. [`XmlrpcClient._tryExecuteCall()`](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/utils/XmlrpcClient.js#L79) actually implements the RPC by passing `_xmlrpcClient` to [`XmlrpcCall.call()`](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/utils/XmlrpcClient.js#L18), which then invokes its `methodCall() function`. Notice that `methodCall()` **belongs to the  [`_xmlrpcClient` property](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/utils/XmlrpcClient.js#L44)**, not to an instance of `XmlrpcClient` itself.

`ParamServerApiClient` also has a property named [`_xmlrpcClient`](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/lib/ParamServerApiClient.js#L28), whose type is the `XmlrpcClient` wrapper above. The functions `getParam` and `setParam` work fine, because they end up using the `call()` interface; however, [`hasParam`](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/ce780e7d7a74d5c854133ca3a3a0745a38045659/src/lib/ParamServerApiClient.js#L91) tries to use `methodCall()`, which as described above belongs to **a property of** `ParamServerApiClient._xmlrpcClient` not to  `ParamServerApiClient._xmlrpcClient` itself. I guess because the property in the `XmlrpcClient` wrapper, and the property in the `ParamServerApiClient` class that _uses the wrapper_ have the same name, the author forgot about the level of indirection.

This commit changes the implementatino of hasParam and getParamNames to use "call" instead of "methodCall", adding the missing layer of indirection.