### PR TITLE
Fix findPackagesInDirectory bug; wait for all packages to be processed before returning

### DIFF
--- a/src/utils/messageGeneration/packages.js
+++ b/src/utils/messageGeneration/packages.js
@@ -200,6 +200,7 @@ function findPackageInDirectory(directory, packageName, callback) {
 function findPackagesInDirectory(directory) {
   const promises = [];
   promises.push(new Promise((resolve) => {
+    const subPromises = [];
     packageWalk(directory)
       .on('package', (packageName, dir, fileName) => {
         packageName = packageName.toLowerCase();
@@ -210,7 +211,7 @@ function findPackagesInDirectory(directory) {
             services: {},
             actions: {}
           };
-          promises.push(new Promise((resolve) => {
+          subPromises.push(new Promise((resolve) => {
             messageWalk(dir, null)
               .on('message', (name, file) => {
                 packageEntry.messages[name] = {file};
@@ -232,7 +233,9 @@ function findPackagesInDirectory(directory) {
           }));
         }
       })
-      .on('end', resolve);
+      .on('end', () => {
+        Promise.all(subPromises).then(resolve);
+      });
   }));
 
   return Promise.all(promises);


### PR DESCRIPTION
I was running the [on_the_fly.js](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/kinetic-devel/src/examples/on_the_fly.js) example on Ubuntu 16.04 and using ros kinect. I added one more line `console.log(rosnodejs.require('dynamic_reconfigure').srv);` below [L12](https://github.com/RethinkRobotics-opensource/rosnodejs/blob/kinetic-devel/src/examples/on_the_fly.js) and it was hanging at the line I just added. It turns out the `rosnodejs.initNode('/my_node', { onTheFly: true})...` did not load all the packages available in my ROS environment and it was because of a bug in `[findPackagesInDirectory](https://github.com/RethinkRobotics-opensource/rosnodejs/compare/kinetic-devel...mjyc:fix-findPackagesInDirectory?expand=1#diff-40b148bb2df8bbbe97c8d6cf607f1be1R200)`. Without this fix, some ROS pacakges may not be processed because [L213](https://github.com/RethinkRobotics-opensource/rosnodejs/compare/kinetic-devel...mjyc:fix-findPackagesInDirectory?expand=1#diff-40b148bb2df8bbbe97c8d6cf607f1be1L213) can be  called after [L238](https://github.com/RethinkRobotics-opensource/rosnodejs/compare/kinetic-devel...mjyc:fix-findPackagesInDirectory?expand=1#diff-40b148bb2df8bbbe97c8d6cf607f1be1L238) .

cc @chfritz @manzato 