### PR TITLE
Implement getPublishedTopics() and getTopicTypes()

### DIFF
--- a/src/lib/MasterApiClient.js
+++ b/src/lib/MasterApiClient.js
@@ -118,12 +118,40 @@ class MasterApiClient {
     });
   }
 
-  getPublishedTopics(callerId, subgraph) {
-    throw new Error('NOT SUPPORTED');
+  getPublishedTopics(callerId, subgraph, options) {
+    let data = [callerId, subgraph];
+    return new Promise((resolve,reject)=>{
+      this._call(
+        'getPublishedTopics', 
+        data, 
+        function(data) {
+          return resolve({
+            topics: data[2].map((topic) => { return {
+              name: topic[0], type: topic[1]
+            }})
+          })
+        }, 
+        reject,
+        options);
+    })
   }
 
-  getTopicTypes(callerId) {
-    throw new Error('NOT SUPPORTED');
+  getTopicTypes(callerId, options) {
+    let data = [callerId];
+    return new Promise((resolve,reject)=>{
+      this._call(
+        'getTopicTypes', 
+        data, 
+        function(data) {
+          return resolve({
+            topics: data[2].map((topic) => { return {
+              name: topic[0], type: topic[1]
+            }})
+          })
+        }, 
+        reject,
+        options);
+    })
   }
 
   /** return an object containing all current publishers (by topic),

--- a/src/lib/NodeHandle.js
+++ b/src/lib/NodeHandle.js
@@ -307,27 +307,12 @@ class NodeHandle {
   }
 
   /**
-   * A list of topics with types
    * @typedef {Object} TopicList
-   * @property {Object[]} topics Contains objects of the format:
-   *                    {
-   *                      name: <string>,
-   *                      type: <string>
-   *                    }
+   * @property {{name: string, type: string}[]} topics Array of topics
    */
 
-  /**
-   * List representation of a system state
-   * @typedef {Object} SystemState
-   * @property {Object.<...string:Array<string>>} publishers dictionary object
-   * containing a list of published topics and their publisher[s]
-   * @property {Object.<...string:Array<string>>} subscribers dictionary object
-   * containing a list of subscribed topics and their subscriber[s]
-   * @property {Object.<...string:Array<string>>} services dictionary object
-   * containing a list of services and their provider[s]
-   */
-
-  /**
+   
+  /** 
    * Get list of topics that can be subscribed to. This does not return
    * topics that have no publishers.
    * 
@@ -335,8 +320,6 @@ class NodeHandle {
    *                          specified subgraph. Subgraph namespace is
    *                          resolved relative to this node's namespace.
    *                          Will return all names if no subgraph is given.
-   * @reject {Error}
-   * @fulfill {TopicList}
    * @return {Promise.<TopicList>}
    */
   getPublishedTopics(subgraph="") {
@@ -346,20 +329,27 @@ class NodeHandle {
   /**
    * Retrieve list topic names and their types.
    * 
-   * @reject {Error}
-   * @fulfill {TopicList}
    * @return {Promise.<TopicList>}
    */
   getTopicTypes() {
     return this._node.getTopicTypes();
   }
 
+
+  /**
+   * @typedef {Object} SystemState
+   * @property {{...string:Array.<string>}} publishers An object with topic names as keys and 
+   * an array of publishers as values
+   * @property {{...string:Array.<string>}} subscribers An object with topic names as keys and 
+   * an array of subscribers as values
+   * @property {{...string:Array.<string>}} services An object with service names as keys and
+   * an array of providers as values
+   */
+
   /**
    * Retrieve list representation of system state (i.e. publishers,
    * subscribers, and services).
    * 
-   * @reject {Error}
-   * @fulfill {TopicList}
    * @return {Promise.<SystemState>}
    */
   getSystemState(){

--- a/src/lib/NodeHandle.js
+++ b/src/lib/NodeHandle.js
@@ -316,7 +316,7 @@ class NodeHandle {
    * Get list of topics that can be subscribed to. This does not return
    * topics that have no publishers.
    * 
-   * @param subgraph {string} Restrict topic names to match within the
+   * @param {string} subgraph Restrict topic names to match within the
    *                          specified subgraph. Subgraph namespace is
    *                          resolved relative to this node's namespace.
    *                          Will return all names if no subgraph is given.

--- a/src/lib/NodeHandle.js
+++ b/src/lib/NodeHandle.js
@@ -23,6 +23,11 @@ const namespaceUtils = require('../utils/namespace_utils.js');
 const ActionClientInterface = require('./ActionClientInterface.js');
 const ActionServerInterface = require('./ActionServerInterface.js');
 
+/**
+ * Handle class for nodes created with rosnodejs
+ * @param node {RosNode} node that handle is attached to.
+ * @param namespace {string} namespace of node. @default null
+ */
 class NodeHandle {
   constructor(node, namespace=null) {
     this._node = node;
@@ -299,6 +304,66 @@ class NodeHandle {
 
   getMasterUri() {
     return this._node.getMasterUri();
+  }
+
+  /**
+   * A list of topics with types
+   * @typedef {Object} TopicList
+   * @property {Object[]} topics Contains objects of the format:
+   *                    {
+   *                      name: <string>,
+   *                      type: <string>
+   *                    }
+   */
+
+  /**
+   * List representation of a system state
+   * @typedef {Object} SystemState
+   * @property {Object.<...string:Array<string>>} publishers dictionary object
+   * containing a list of published topics and their publisher[s]
+   * @property {Object.<...string:Array<string>>} subscribers dictionary object
+   * containing a list of subscribed topics and their subscriber[s]
+   * @property {Object.<...string:Array<string>>} services dictionary object
+   * containing a list of services and their provider[s]
+   */
+
+  /**
+   * Get list of topics that can be subscribed to. This does not return
+   * topics that have no publishers.
+   * 
+   * @param subgraph {string} Restrict topic names to match within the
+   *                          specified subgraph. Subgraph namespace is
+   *                          resolved relative to this node's namespace.
+   *                          Will return all names if no subgraph is given.
+   * @reject {Error}
+   * @fulfill {TopicList}
+   * @return {Promise.<TopicList>}
+   */
+  getPublishedTopics(subgraph="") {
+    return this._node.getPublishedTopics(subgraph);
+  }
+
+  /**
+   * Retrieve list topic names and their types.
+   * 
+   * @reject {Error}
+   * @fulfill {TopicList}
+   * @return {Promise.<TopicList>}
+   */
+  getTopicTypes() {
+    return this._node.getTopicTypes();
+  }
+
+  /**
+   * Retrieve list representation of system state (i.e. publishers,
+   * subscribers, and services).
+   * 
+   * @reject {Error}
+   * @fulfill {TopicList}
+   * @return {Promise.<SystemState>}
+   */
+  getSystemState(){
+    return this._node.getSystemState();    
   }
 
 //------------------------------------------------------------------

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -276,6 +276,18 @@ class RosNode extends EventEmitter {
     return this._masterApi.getUri(this._nodeName, options);
   }
 
+  getPublishedTopics(subgraph, options) {
+    return this._masterApi.getPublishedTopics(this._nodeName, subgraph, options);
+  }
+
+  getTopicTypes(options) {
+    return this._masterApi.getTopicTypes(this._nodeName, options);
+  }
+
+  getSystemState(options) {
+    return this._masterApi.getSystemState(this._nodeName, options);
+  }
+
   /**
    * Delays xmlrpc calls until our servers are set up
    * Since we need their ports for most of our calls.


### PR DESCRIPTION
This PR implements getPublishedTopics() and getTopicTypes() in MasterApiClient, and creates interfaces for these in RosNode and NodeHandle.
This PR also creates interfaces for GetSystemState() in RosNode and NodeHandle.