### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,69 @@
+dist: trusty
+sudo: required
+compiler:
+  - gcc
 language: node_js
 node_js:
   - "6"
   - "7"
+  - "8"
 env:
-  - CMAKE_PREFIX_PATH=${TRAVIS_BUILD_DIR}
+  global:
+    - ROS_DISTRO=indigo
+    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
+    - CI_SOURCE_PATH=$(pwd)
+    - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
+    - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
+    - ROS_PARALLEL_JOBS='-j8 -l6'
+    # Set the python path manually to include /usr/-/python2.7/dist-packages
+    # as this is where apt-get installs python packages.
+    - PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
+branches:
+  only:
+    - kinetic-devel
+
+# Install system dependencies, namely a very barebones ROS setup.
+before_install:
+  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  - sudo apt-get update -qq
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  # Prepare rosdep to install dependencies.
+  - sudo rosdep init
+  - rosdep update
+  
+# Create a catkin workspace with the package under integration.
+install:
+  - mkdir -p ~/catkin_ws/src
+  - cd ~/catkin_ws/src
+  - catkin_init_workspace
+  # Create the devel/setup.bash (run catkin_make with an empty workspace) and
+  # source it to set the path variables.
+  - cd ~/catkin_ws  
+  - catkin_make
+  - source devel/setup.bash
+  
+  # Install required message packages
+  - git clone https://github.com/ros/std_msgs.git src/std_msgs
+  - git clone https://github.com/ros/common_msgs src/common_msgs
+  - git clone https://github.com/RethinkRobotics-opensource/test_msgs.git src/test_msgs
+  - git clone https://github.com/ros/ros_comm_msgs.git src/ros_comm_msgs
+  # Install all dependencies, using wstool first and rosdep second.
+  # wstool looks for a ROSINSTALL_FILE defined in the environment variables.
+  - cd ~/catkin_ws/src
+  - wstool init
+  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+  - wstool up
+  # package depdencies: install using rosdep.
+  - cd ~/catkin_ws
+  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+  - source devel/setup.bash
+
 script:
+  - cd $CI_SOURCE_PATH
   - npm install
+  - npm run compile
+  - npm run generate
+  - npm test
+  


### PR DESCRIPTION
-Add minimal ros install in order to actually run tests.
-Currently just runs against 14.04 and indigo. Also running against 16.04 and kinetic will require setting up travis with docker.
-compiles, generates messages, and tests against latest of Node 6, 7, and 8.