### PR TITLE
Added goal to GoalHandle

### DIFF
--- a/src/actions/ActionServer.js
+++ b/src/actions/ActionServer.js
@@ -103,7 +103,7 @@ class ActionServer extends EventEmitter {
       return false;
     }
 
-    handle = new GoalHandle(msg.goal_id, this);
+    handle = new GoalHandle(msg.goal_id, this, GoalStatuses.PENDING, msg.goal);
     this._goalHandleList.push(handle);
     this._goalHandleCache[handle.id] = handle;
 

--- a/src/actions/GoalHandle.js
+++ b/src/actions/GoalHandle.js
@@ -33,7 +33,6 @@ class GoalHandle {
    *  this goal is used to represent a cancellation.
    */
   constructor(goalId, actionServer, status, goal) {
-    this.goal = goal;
     if (goalId.id === '') {
       goalId = actionServer.generateGoalId();
     }
@@ -55,6 +54,8 @@ class GoalHandle {
       status: status || GoalStatuses.PENDING,
       goal_id: goalId
     });
+
+    this._goal = goal;
 
     this._destructionTime = timeUtils.epoch();
   }
@@ -79,6 +80,10 @@ class GoalHandle {
 
   getGoalStatus() {
     return this._status;
+  }
+
+  getGoal() {
+    return this._goal;
   }
 
   publishFeedback(feedback) {

--- a/src/actions/GoalHandle.js
+++ b/src/actions/GoalHandle.js
@@ -25,7 +25,15 @@ let GoalStatus = null;
 let GoalStatuses = null;
 
 class GoalHandle {
-  constructor(goalId, actionServer, status) {
+  /**
+   * goalId: An actionlib_msgs/GoalID.
+   * actionServer: The ActionServer processing this goal
+   * status: A number from actionlib_msgs/GoalStatus, like GoalStatuses.PENDING.
+   * goal: The goal message, e.g., a FibonacciGoal. May be left undefined if
+   *  this goal is used to represent a cancellation.
+   */
+  constructor(goalId, actionServer, status, goal) {
+    this.goal = goal;
     if (goalId.id === '') {
       goalId = actionServer.generateGoalId();
     }


### PR DESCRIPTION
Relevant to #88.

This change makes the ActionServer pass the goal message to a GoalHandle, which is stored in the `.goal` field. When GoalHandles are created for cancellations, the goal message is left undefined.

This incorporates changes from #91. I put the changes from #91 into a separate pull request since it's a straightforward typo fix, whereas I'm not sure if this is the best way to fix #88.