### PR TITLE
Throw errors from requiring messages

### DIFF
--- a/src/utils/message_utils.js
+++ b/src/utils/message_utils.js
@@ -170,12 +170,7 @@ let MessageUtils = {
   },
 
   loadMessagePackage(msgPackage) {
-    try {
-      messagePackageMap[msgPackage] = ros_msg_utils.Find(msgPackage);
-    }
-    catch (err) {
-      throw new Error(`Unable to include message package ${msgPackage} - ${err}`);
-    }
+    messagePackageMap[msgPackage] = ros_msg_utils.Find(msgPackage);
   },
 
   getPackage(msgPackage) {
@@ -193,12 +188,8 @@ let MessageUtils = {
     // pre-compiled versions
     let pack = this.getPackage(msgPackage);
     if (!pack) {
-      try {
-        this.loadMessagePackage(msgPackage);
-        return this.getPackage(msgPackage);
-      }
-      catch(err) {
-      }
+      this.loadMessagePackage(msgPackage);
+      return this.getPackage(msgPackage);
     }
     // else
     return pack;

--- a/test/directory.js
+++ b/test/directory.js
@@ -4,3 +4,4 @@ require('./SpinnerTest.js');
 require('./xmlrpcTest.js');
 require('./Log.js');
 require('./onTheFly.js');
+require('./messages.js');

--- a/test/messages.js
+++ b/test/messages.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const rosnodejs = require('../src/index.js');
+
+describe('messages', function () {
+
+  it('real messages', function() {
+    expect(rosnodejs.require('geometry_msgs')).to.not.be.empty;
+    expect(rosnodejs.require('geometry_msgs').msg).to.not.be.empty;
+    expect(rosnodejs.require('geometry_msgs').msg).to.have.keys(
+      'Accel','AccelStamped','AccelWithCovariance','AccelWithCovarianceStamped',
+      'Inertia','InertiaStamped','Point','Point32','PointStamped',
+      'Polygon','PolygonStamped','Pose','Pose2D','PoseArray','PoseStamped',
+      'PoseWithCovariance','PoseWithCovarianceStamped','Quaternion',
+      'QuaternionStamped','Transform','TransformStamped','Twist','TwistStamped',
+      'TwistWithCovariance','TwistWithCovarianceStamped','Vector3',
+      'Vector3Stamped','Wrench','WrenchStamped'
+    );
+    expect(rosnodejs.require('geometry_msgs').srv).to.be.empty;
+
+    expect(rosnodejs.require('std_msgs')).to.not.be.empty;
+    expect(rosnodejs.require('std_msgs').msg).to.not.be.empty;
+    expect(rosnodejs.require('std_msgs').msg).to.have.keys(
+      'Bool','Duration','Float64MultiArray','Int32MultiArray',
+      'MultiArrayDimension','UInt16MultiArray','UInt8','Byte','Empty','Header',
+      'Int64','MultiArrayLayout','UInt32','UInt8MultiArray','ByteMultiArray',
+      'Float32','Int16','Int64MultiArray','String','UInt32MultiArray','Char',
+      'Float32MultiArray','Int16MultiArray','Int8','Time','UInt64','ColorRGBA',
+      'Float64','Int32','Int8MultiArray','UInt16','UInt64MultiArray'
+    )
+    expect(rosnodejs.require('std_msgs').srv).to.be.empty;
+
+    expect(rosnodejs.require('std_srvs')).to.not.be.empty;
+    expect(rosnodejs.require('std_srvs').msg).to.be.empty;
+    expect(rosnodejs.require('std_srvs').srv).to.not.be.empty;
+    expect(rosnodejs.require('std_srvs').srv).to.have.keys(
+      'Empty','SetBool','Trigger'
+    );
+
+    expect(rosnodejs.require('test_msgs')).to.not.be.empty;
+    expect(rosnodejs.require('test_msgs').msg).to.not.be.empty;
+    expect(rosnodejs.require('test_msgs').msg).to.have.keys(
+      'AllTypes','BaseTypeConstantLengthArray','ConstantLengthArray',
+      'VariableLengthArray','BaseType','BaseTypeVariableLengthArray','StdMsg',
+      "TestActionAction","TestActionActionFeedback","TestActionActionGoal",
+      "TestActionActionResult","TestActionFeedback","TestActionGoal",
+      "TestActionResult"
+    );
+    expect(rosnodejs.require('test_msgs').srv).to.not.be.empty;
+    expect(rosnodejs.require('test_msgs').srv).to.have.keys(
+      'BasicService','HeaderService','NonSpecServiceDivider','TestService'
+    );
+  });
+
+  it('non-existant messages', function() {
+    const nonExistantPkg = 'made_up_message_package';
+    expect(rosnodejs.require.bind(rosnodejs, nonExistantPkg)).to.throw(
+      Error, `Unable to find message package ${nonExistantPkg} from CMAKE_PREFIX_PATH`
+    );
+  });
+});


### PR DESCRIPTION
-If an error occurs while requiring a message package, throw it.
-Add tests for expected messages, throwing error when message doesn't exist

Relates to #93, #85 