### PR TITLE
Add action.start to make rosnodejs' ActionServer compatible with ActionClient in python & C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ const as = new rosnodejs.ActionServer({
   actionServer: '/turtle_shape'
 });
 
-as.on('goal, function (goal) {
+as.on('goal', function (goal) {
   goal.setAccepted();
 });
 
-const ac = nh.actionClientInterface('/turtle_shape, 'turtle_actionlib/ShapeAction');
+as.start();
+
+const ac = nh.actionClientInterface('/turtle_shape', 'turtle_actionlib/ShapeAction');
 ac.sendGoal({ goal: {edges: 3, radius: 1}});
 ```
 ## Run the turtlesim example

--- a/src/actions/ActionServer.js
+++ b/src/actions/ActionServer.js
@@ -73,11 +73,19 @@ class ActionServer extends EventEmitter {
 
     this._lastCancelStamp = timeUtils.epoch();
 
+    this._statusFrequency = 5;
     this._statusListTimeout = 5;
+
+    this._started = false;
   }
 
   generateGoalId() {
     return this._asInterface.generateGoalId();
+  }
+
+  start() {
+    this._started = true;
+    setInterval(this.publishStatus.bind(this), 1000 / this._statusFrequency);
   }
 
   shutdown() {
@@ -89,6 +97,10 @@ class ActionServer extends EventEmitter {
   }
 
   _handleGoal(msg) {
+    if (!this._started) {
+      return;
+    }
+
     const newGoalId = msg.goal_id.id;
 
     let handle = this._getGoalHandle(newGoalId);
@@ -123,6 +135,10 @@ class ActionServer extends EventEmitter {
   }
 
   _handleCancel(msg) {
+    if (!this._started) {
+      return;
+    }
+
     const cancelId = msg.id;
     const cancelStamp = msg.stamp;
     const cancelStampIsZero = timeUtils.isZeroTime(cancelStamp);

--- a/src/actions/ActionServer.js
+++ b/src/actions/ActionServer.js
@@ -75,6 +75,7 @@ class ActionServer extends EventEmitter {
 
     this._statusFrequency = 5;
     this._statusListTimeout = 5;
+    this._statusHandle = null;
 
     this._started = false;
   }
@@ -85,10 +86,11 @@ class ActionServer extends EventEmitter {
 
   start() {
     this._started = true;
-    setInterval(this.publishStatus.bind(this), 1000 / this._statusFrequency);
+    this._statusHandle = setInterval(this.publishStatus.bind(this), 1000 / this._statusFrequency);
   }
 
   shutdown() {
+    clearInterval(this._statusHandle);
     return this._asInterface.shutdown();
   }
 


### PR DESCRIPTION
Hi authors of rosnodejs, first, thanks for implementing ActionServer in rosnodejs! It helped me write more ROS nodes in nodejs.

When I started to use ActionServer more, I realized the `wait_for_server` function in ActionClients python / C++ hangs when it is waiting on a rosnodejs' ActionServer. Looking into [action_server.py implemention](http://docs.ros.org/diamondback/api/actionlib/html/action__client_8py_source.html#l00572). I realized it needs to receive status msg at least once (L576).

This PR solves the "hanging" problem by publishing status msg regularly, as in [action_server.py](http://docs.ros.org/diamondback/api/actionlib/html/action__server_8py_source.html#l00134) (see L157). One problem is, I use `setTimeout`, which does not use ROS timer. I looked in this repo to see if you have an example of using ROS timer to call event callbacks but didn't find one, so I left my solution as is. Let me know what you think,

Btw, you can reproduce the bug I'm talking about by first creating a simple action server in node:

```js
#!/usr/bin/env node

const rosnodejs = require('./index.js');  // rosnodejs

rosnodejs.initNode('fibonacci', {onTheFly: true}).then((nh) => {

  const as = new rosnodejs.ActionServer({
    nh,
    type: 'actionlib_tutorials/Fibonacci',
    actionServer: '/fibonacci'
  });

  as.start();

  as.on('goal', function (goal) {
    goal.setAccepted();
    setTimeout(() => {
      goal.setSucceeded();
    }, 1000);
  });


});
```

and trying to call it using python/C++ action client, e.g. `rosrun actionlib axclient.py /fibonacci actionlib_tutorials/FibonacciAction`. The client will wait for the server forever.

