### PR TITLE
Remove latching from action client publications

### DIFF
--- a/src/lib/ActionClientInterface.js
+++ b/src/lib/ActionClientInterface.js
@@ -41,12 +41,12 @@ class ActionClientInterface extends EventEmitter {
 
     const nh = options.nh;
 
-    const goalOptions = Object.assign({ queueSize: 10, latching: true }, options.goal);
+    const goalOptions = Object.assign({ queueSize: 10, latching: false }, options.goal);
     this._goalPub = nh.advertise(this._actionServer + '/goal',
                                  this._actionType + 'Goal',
                                  goalOptions);
 
-    const cancelOptions = Object.assign({ queueSize: 10, latching: true }, options.cancel);
+    const cancelOptions = Object.assign({ queueSize: 10, latching: false }, options.cancel);
     this._cancelPub = nh.advertise(this._actionServer + '/cancel',
                                    'actionlib_msgs/GoalID',
                                    cancelOptions);


### PR DESCRIPTION
I order to be consistent with [the C++ implementation of the action lib client](https://github.com/ros/actionlib/blob/b90c0f5921375a4412af23e3e9871245977e7cc0/include/actionlib/client/action_client.h#L253-L264), I think we should make latching of action client publications false by default.