### PR TITLE
Better CMAKE_PREFIX_PATH error

### DIFF
--- a/src/ros_msg_utils/lib/message_cache.js
+++ b/src/ros_msg_utils/lib/message_cache.js
@@ -21,6 +21,9 @@ const fs = require('fs');
 const path = require('path');
 
 const CMAKE_PREFIX_PATH = process.env.CMAKE_PREFIX_PATH;
+if (!CMAKE_PREFIX_PATH) {
+  throw new Error('Unable to find CMAKE_PREFIX_PATH environment variable. Did you source setup.bash?')
+}
 const cmakePaths = CMAKE_PREFIX_PATH.split(path.delimiter);
 const jsMsgPath = path.join('share', 'gennodejs', 'ros');
 


### PR DESCRIPTION
Throw a useful error for people if CMAKE_PREFIX_PATH is not set, rather than throwing a less intelligible error a line later.