### PR TITLE
Changed ActionClientInterface to expect action type names without extra "Action" appended

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const client = nh.serviceClient('/add_two_ints', AddTwoInts);
 const nh = rosnodejs.nh;
 const as = new rosnodejs.ActionServer({
   nh,
-  type: 'turtle_actionlib/ShapeAction',
+  type: 'turtle_actionlib/Shape',
   actionServer: '/turtle_shape'
 });
 
@@ -102,7 +102,7 @@ as.on('goal', function (goal) {
 
 as.start();
 
-const ac = nh.actionClientInterface('/turtle_shape', 'turtle_actionlib/ShapeAction');
+const ac = nh.actionClientInterface('/turtle_shape', 'turtle_actionlib/Shape');
 ac.sendGoal({ goal: {edges: 3, radius: 1}});
 ```
 ## Run the turtlesim example

--- a/src/examples/turtle.js
+++ b/src/examples/turtle.js
@@ -77,7 +77,7 @@ rosnodejs.initNode('/my_node', {onTheFly: true}).then((rosNode) => {
       const shapeActionGoal = rosnodejs.require('turtle_actionlib').msg.ShapeActionGoal;
       const ac = rosnodejs.nh.actionClient(
         "/turtle_shape",
-        "turtle_actionlib/ShapeAction"
+        "turtle_actionlib/Shape"
       );
       ac.sendGoal(new shapeActionGoal({
             goal: {

--- a/src/lib/ActionClientInterface.js
+++ b/src/lib/ActionClientInterface.js
@@ -43,7 +43,7 @@ class ActionClientInterface extends EventEmitter {
 
     const goalOptions = Object.assign({ queueSize: 10, latching: false }, options.goal);
     this._goalPub = nh.advertise(this._actionServer + '/goal',
-                                 this._actionType + 'Goal',
+                                 this._actionType + 'ActionGoal',
                                  goalOptions);
 
     const cancelOptions = Object.assign({ queueSize: 10, latching: false }, options.cancel);
@@ -59,13 +59,13 @@ class ActionClientInterface extends EventEmitter {
 
     const feedbackOptions = Object.assign({ queueSize: 1 }, options.feedback);
     this._feedbackSub = nh.subscribe(this._actionServer + '/feedback',
-                                     this._actionType + 'Feedback',
+                                     this._actionType + 'ActionFeedback',
                                      (msg) => { this._handleFeedback(msg); },
                                      feedbackOptions);
 
     const resultOptions = Object.assign({ queueSize: 1 }, options.result);
     this._resultSub = nh.subscribe(this._actionServer + '/result',
-                                   this._actionType + 'Result',
+                                   this._actionType + 'ActionResult',
                                    (msg) => { this._handleResult(msg); },
                                    resultOptions);
 

--- a/src/lib/NodeHandle.js
+++ b/src/lib/NodeHandle.js
@@ -207,7 +207,7 @@ class NodeHandle {
    * @param  {String} actionServer name of the action server
    * (e.g., "/turtle_shape")
    * @param  {String} type action type 
-   * (e.g., "turtle_actionlib/ShapeAction")
+   * (e.g., "turtle_actionlib/Shape")
    * @return {[type]} an instance of ActionClientInterface
    */
   actionClientInterface(actionServer, type, options = {}) {
@@ -216,10 +216,6 @@ class NodeHandle {
     }
     else if (!type) {
       throw new Error(`Unable to create action client ${actionServer} without type - got ${type}`);
-    }
-
-    if (!type.endsWith('Action')) {
-      type += 'Action';
     }
 
     // don't namespace action client - topics will be resolved by


### PR DESCRIPTION
Fixes #104 

Changes the ActionClientInterface such that the type name is always of the form: `my_msgs/DoSomething`, where the action was defined in a file `DoSomething.action` in the package `my_msgs`.

**This is a breaking change!**
- If you previously provided the name with the word "Action" at the end, this will no longer work:
  ```diff
  - const ac = nh.actionClientInterface('/turtle_shape', 'turtle_actionlib/ShapeAction');
  ```
  You must remove the extra "Action" from the action type name:
  ```diff
  + const ac = nh.actionClientInterface('/turtle_shape', 'turtle_actionlib/Shape');
  ```
- If you had an action whose name actually ended with "Action" (e.g., MyAction.action) and passed in the action name as "MyActionAction", you must also remove the extra "Action":
  ```diff
  - const ac = nh.actionClientInterface('/turtle_shape', 'my_msgs/MyActionAction');
  + const ac = nh.actionClientInterface('/turtle_shape', 'my_msgs/MyAction');
  ```
- If your action type did not include the extra "Action", no changes are necessary:
  ```js
  const ac = nh.actionClientInterface('/turtle_shape', 'turtle_actionlib/Shape');
  ```