### PR TITLE
Fix for ROS on IPv6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 compiler:
   - gcc
@@ -7,9 +7,10 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "10"
 env:
   global:
-    - ROS_DISTRO=indigo
+    - ROS_DISTRO=kinetic
     - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
     - CI_SOURCE_PATH=$(pwd)
     - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
@@ -26,9 +27,9 @@ branches:
 before_install:
   - sudo apt-get install -y dpkg  # to upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -372,7 +372,7 @@ class RosNode extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      const server = xmlrpc.createServer({host: '0.0.0.0', port: xmlrpcPort}, () => {
+      const server = xmlrpc.createServer({port: xmlrpcPort}, () => {
         const {port} = server.httpServer.address();
         this._debugLog.debug('Slave API Listening on port ' + port);
         this._xmlrpcPort = port;
@@ -456,7 +456,7 @@ class RosNode extends EventEmitter {
       if (tcprosPort === null) {
         tcprosPort = 0;
       }
-      server.listen(tcprosPort, '0.0.0.0');
+      server.listen(tcprosPort);
 
       this._tcprosServer = server;
 


### PR DESCRIPTION
Removing the default host '0.0.0.0' causes server to automatically choose between '0.0.0.0' and `::1` depending on network type (IPv4 vs IPv6).