### PR TITLE
Add test for UTF-8 string content

### DIFF
--- a/test/onTheFly.js
+++ b/test/onTheFly.js
@@ -29,23 +29,23 @@ describe('OnTheFly', function () {
     return master.shutdown();
   });
 
-  const geometry_msgs = rosnodejs.require('geometry_msgs').msg;
-  const msg = new geometry_msgs.PoseWithCovariance({
-      pose: {
-        position: {x:0, y:0, z:0},
-        orientation: {w:1, x:0, y:0, z:0}
-      },
-      covariance: [
-        0,0,0,0,0,0.123,
-        0,2,0,0,0,0,
-        0,0,4,0,0,0,
-        0,0,0,6,0,0,
-        0,0,0,0,8,0,
-        0.123,0,0,0,0,0.654321654321
-      ]
-    });
+  it('serialize/deserialize PoseWithCovariance', (done) => {
+    const geometry_msgs = rosnodejs.require('geometry_msgs').msg;
+    const msg = new geometry_msgs.PoseWithCovariance({
+        pose: {
+          position: {x:0, y:0, z:0},
+          orientation: {w:1, x:0, y:0, z:0}
+        },
+        covariance: [
+          0,0,0,0,0,0.123,
+          0,2,0,0,0,0,
+          0,0,4,0,0,0,
+          0,0,0,6,0,0,
+          0,0,0,0,8,0,
+          0.123,0,0,0,0,0.654321654321
+        ]
+      });
 
-  it('serialize/deserialize', (done) => {
     const size = geometry_msgs.PoseWithCovariance.getMessageSize(msg);
     const buffer = new Buffer(size);
     geometry_msgs.PoseWithCovariance.serialize(msg, buffer, 0);
@@ -53,6 +53,23 @@ describe('OnTheFly', function () {
     const read = geometry_msgs.PoseWithCovariance.deserialize(buffer);
     expect(read.covariance.length == msg.covariance.length
       && read.covariance.every((v,i)=> v === msg.covariance[i])).to.be.true;
+
+    done();
+  });
+
+  it('serialize/deserialize String', (done) => {
+    const std_msgs = rosnodejs.require('std_msgs').msg;
+    const data = 'sДvΣ τhΣ 子猫';  // Test with multi-byte UTF-8 characters.
+                                   // If this test fails, you killed a kitten.
+    const msg = new std_msgs.String({ data: data });
+
+    const size = std_msgs.String.getMessageSize(msg);
+
+    const buffer = new Buffer(size);
+    std_msgs.String.serialize(msg, buffer, 0);
+
+    const read = std_msgs.String.deserialize(buffer);
+    expect(read.data).to.deep.equal(data);
 
     done();
   });


### PR DESCRIPTION
A test for #132 to ensure multi-byte UTF-8 characters can be serialized and deserialized properly.