### PR TITLE
Fix regex for parsing url.

### DIFF
--- a/src/utils/network_utils.js
+++ b/src/utils/network_utils.js
@@ -74,7 +74,7 @@ const NetworkUtils = {
   },
 
   getAddressAndPortFromUri(uriString) {
-    let regexStr = /(?:http:\/\/|rosrpc:\/\/)?([a-zA-Z\d\-.:]+):(\d+)/;
+    let regexStr = /(?:http:\/\/|rosrpc:\/\/)?([a-zA-Z\d\-_.]+):(\d+)/;
     let match = uriString.match(regexStr);
     if (match === null) {
       throw new Error ('Unable to find host and port from uri ' + uriString + ' with regex ' +  regexStr);


### PR DESCRIPTION
Added `_` to the valid characters in the hostname. Note that I also removed the `:`. I think that's only be allowed at the end (where we already have it), before the port.

Fixes #136.