### PR TITLE
Fix error on action cancellation

### DIFF
--- a/src/actions/ClientGoalHandle.js
+++ b/src/actions/ClientGoalHandle.js
@@ -83,7 +83,7 @@ class ClientGoalHandle extends EventEmitter {
         return;
     }
 
-    this._actionClient.cancel(this._goal.goal_id.id, { secs: 0, nsecs: 0 });
+    this._clientInterface.cancel(this._goal.goal_id.id, { secs: 0, nsecs: 0 });
     this._transition(CommState.WAITING_FOR_CANCEL_ACK);
   }
 


### PR DESCRIPTION
By using `_clientInterface` instead of `_actionClient` we prevent the following error : "TypeError: Cannot read property 'cancel' of undefined" caused by the fact that `_actionClient` is never properly assigned.