### PR TITLE
Process exit on sigint only if forceExit is specified

### DIFF
--- a/src/examples/standard.js
+++ b/src/examples/standard.js
@@ -4,7 +4,7 @@ let rosnodejs = require('../index.js');
 const std_msgs = rosnodejs.require('std_msgs').msg;
 const SetBool = rosnodejs.require('std_srvs').srv.SetBool;
 
-rosnodejs.initNode('/test_node')
+rosnodejs.initNode('/test_node', { node: { forceExit: true }})
 .then((rosNode) => {
   // EXP 1) Service Server
   let service = rosNode.advertiseService('set_bool', SetBool,

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -80,7 +80,7 @@ class RosNode extends EventEmitter {
     this._setupTcprosServer(options.tcprosPort)
     .then(this._setupSlaveApi.bind(this, options.xmlrpcPort));
 
-    this._setupExitHandler();
+    this._setupExitHandler(options.forceExit);
 
     this._setupSpinner(options.spinner);
 
@@ -662,7 +662,7 @@ class RosNode extends EventEmitter {
     }
   }
 
-  _setupExitHandler() {
+  _setupExitHandler(forceExit) {
     // we need to catch that this process is about to exit so we can unregister all our
     // publishers, subscribers, and services
 
@@ -766,7 +766,7 @@ class RosNode extends EventEmitter {
     this._exit = exitImpl;
 
     exitHandler = exitImpl.bind(this);
-    sigIntHandler = exitImpl.bind(this, true);
+    sigIntHandler = exitImpl.bind(this, !!forceExit);
 
     process.once('exit', exitHandler );
     process.once('SIGINT', sigIntHandler );


### PR DESCRIPTION
Remove behavior that defaults to calling `process.exit()` on `SIGINT`. User can override with `forceExit` flag in node options.

Resolves #154 