### PR TITLE
TF topic check, add message size and node uri, fix Buffer deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "moment": "2.22.2",
     "ultron": "1.1.1",
     "walker": "1.0.7",
-    "xmlrpc": "chfritz/node-xmlrpc"
+    "xmlrpc-rosnodejs": "1.4.0"
   }
 }

--- a/src/lib/MasterApiClient.js
+++ b/src/lib/MasterApiClient.js
@@ -17,7 +17,7 @@
 
 "use strict";
 
-let xmlrpc = require('xmlrpc');
+let xmlrpc = require('xmlrpc-rosnodejs');
 let networkUtils = require('../utils/network_utils.js');
 let Logging = require('./Logging.js');
 const XmlrpcClient = require('../utils/XmlrpcClient.js');

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -18,7 +18,7 @@
 "use strict"
 
 let net = require('net');
-let xmlrpc = require('xmlrpc');
+let xmlrpc = require('xmlrpc-rosnodejs');
 let MasterApiClient  = require('./MasterApiClient.js');
 let SlaveApiClient = require('./SlaveApiClient.js');
 let ParamServerApiClient = require('./ParamServerApiClient.js');

--- a/src/lib/SlaveApiClient.js
+++ b/src/lib/SlaveApiClient.js
@@ -17,7 +17,7 @@
 
 "use strict";
 
-let xmlrpc = require('xmlrpc');
+let xmlrpc = require('xmlrpc-rosnodejs');
 
 //-----------------------------------------------------------------------
 

--- a/src/lib/impl/SubscriberImpl.js
+++ b/src/lib/impl/SubscriberImpl.js
@@ -507,7 +507,7 @@ class SubscriberImpl extends EventEmitter {
   _handleMsgQueue(msgQueue) {
     try {
       msgQueue.forEach((msg) => {
-        this.emit('message', this._messageHandler.deserialize(msg));
+        this.emit('message', this._messageHandler.deserialize(msg), msg.length);
       });
     }
     catch (err) {

--- a/src/utils/XmlrpcClient.js
+++ b/src/utils/XmlrpcClient.js
@@ -1,6 +1,6 @@
 'use strict';
 const EventEmitter = require('events');
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 
 const CONNECTION_REFUSED='ECONNREFUSED';
 const TRY_AGAIN_LIST = [1, 2, 2, 4, 4, 4, 4, 8, 8, 8, 8, 16, 16, 32, 64, 128, 256, 512, 1024, 2048];

--- a/src/utils/serialization_utils.js
+++ b/src/utils/serialization_utils.js
@@ -109,7 +109,7 @@ class DeserializeStream extends Transform  {
           // if its an empty message, there won't be any bytes left and message
           // will never be emitted -- handle that case here
           if (this._messageLen === 0 && pos === chunkLen) {
-            this.emitMessage(new Buffer([]));
+            this.emitMessage(Buffer.from([]));
           }
           else {
             this._inBody = true;
@@ -144,7 +144,7 @@ class DeserializeStream extends Transform  {
 //-----------------------------------------------------------------------
 
 function PrependLength(buffer, len) {
-  let lenBuf = new Buffer(4);
+  let lenBuf = Buffer.allocUnsafe(4);
   lenBuf.writeUInt32LE(len, 0);
   return Buffer.concat([lenBuf, buffer], buffer.length + 4);
 }

--- a/src/utils/tcpros_utils.js
+++ b/src/utils/tcpros_utils.js
@@ -41,7 +41,7 @@ function serializeStringFields(fields) {
   fields.forEach((field) => {
     length += (Buffer.byteLength(field) + 4);
   });
-  let buffer = new Buffer(4 + length);
+  let buffer = Buffer.allocUnsafe(4 + length);
   let offset = base_serializers.uint32(length, buffer, 0);
 
   fields.forEach((field) => {
@@ -214,11 +214,11 @@ let TcprosUtils = {
     let msgBuffer;
     let offset = 0;
     if (prependMessageLength) {
-      msgBuffer = new Buffer(msgSize + 4);
+      msgBuffer = Buffer.allocUnsafe(msgSize + 4);
       offset = base_serializers.uint32(msgSize, msgBuffer, 0);
     }
     else {
-      msgBuffer = new Buffer(msgSize);
+      msgBuffer = Buffer.allocUnsafe(msgSize);
     }
 
     MessageClass.serialize(message, msgBuffer, offset);
@@ -230,7 +230,7 @@ let TcprosUtils = {
     if (prependResponseInfo) {
       if (success) {
         const respSize = ResponseClass.getMessageSize(response);
-        responseBuffer = new Buffer(respSize + 5);
+        responseBuffer = Buffer.allocUnsafe(respSize + 5);
 
         // add the success byte
         base_serializers.uint8(1, responseBuffer, 0);
@@ -242,13 +242,13 @@ let TcprosUtils = {
         const errorMessage = 'Unable to handle service call';
         const errLen = errorMessage.length;
         // FIXME: check that we don't need the extra 4 byte message len here
-        responseBuffer = new Buffer(5 + errLen);
+        responseBuffer = Buffer.allocUnsafe(5 + errLen);
         base_serializers.uint8(0, responseBuffer, 0);
         base_serializers.string(errorMessage, responseBuffer, 1);
       }
     }
     else {
-      responseBuffer = new Buffer(ResponseClass.getMessageSize(response));
+      responseBuffer = Buffer.allocUnsafe(ResponseClass.getMessageSize(response));
     }
 
     return responseBuffer;
@@ -259,7 +259,7 @@ let TcprosUtils = {
   },
 
   serializeString(str) {
-    const buf = new Buffer(str.length + 4);
+    const buf = Buffer.allocUnsafe(str.length + 4);
     base_serializers.string(str, buf, 0);
     return buf;
   },

--- a/src/utils/tcpros_utils.js
+++ b/src/utils/tcpros_utils.js
@@ -181,10 +181,12 @@ let TcprosUtils = {
     else if (!header.hasOwnProperty('md5sum')) {
       return this.serializeString('Connection header missing expected field [md5sum]');
     }
-    // rostopic will send '*' for some commands (hz)
-    else if (header.type !== type && header.type !== '*') {
-      return this.serializeString('Got incorrect message type [' + header.type + '] expected [' + type + ']');
-    }
+    /* Note that we are not checking the type of the incoming message against the type specified during
+       susbscription. If we did, then this would break subscriptions to the `/tf` topic, where messages
+       can be either tf/tfMessage (gazebo) or tf2_msgs/TFMessage (everywhere else), even though their md5 and
+       type definitions are actually the same. This is in-line with rospy, where the type isn't checked either:
+       https://github.com/ros/ros_comm/blob/6292d54dc14395531bffb2e165f3954fb0ef2c34/clients/rospy/src/rospy/impl/tcpros_pubsub.py#L332-L336
+    */
     else if (header.md5sum !== md5sum && header.md5sum !== '*') {
       return this.serializeString('Got incorrect md5sum [' + header.md5sum + '] expected [' + md5sum + ']');
     }

--- a/src/utils/udpros_utils.js
+++ b/src/utils/udpros_utils.js
@@ -41,7 +41,7 @@ function serializeStringFields(fields) {
   fields.forEach((field) => {
     length += (field.length + 4);
   });
-  let buffer = new Buffer(length);
+  let buffer = Buffer.allocUnsafe(length);
   let offset = 0
 
   fields.forEach((field) => {
@@ -201,11 +201,11 @@ let UdprosUtils = {
     let msgBuffer;
     let offset = 0;
     if (prependMessageLength) {
-      msgBuffer = new Buffer(msgSize + 4);
+      msgBuffer = Buffer.allocUnsafe(msgSize + 4);
       offset = base_serializers.uint32(msgSize, msgBuffer, 0);
     }
     else {
-      msgBuffer = new Buffer(msgSize);
+      msgBuffer = Buffer.allocUnsafe(msgSize);
     }
 
     MessageClass.serialize(message, msgBuffer, offset);
@@ -217,7 +217,7 @@ let UdprosUtils = {
     if (prependResponseInfo) {
       if (success) {
         const respSize = ResponseClass.getMessageSize(response);
-        responseBuffer = new Buffer(respSize + 5);
+        responseBuffer = Buffer.allocUnsafe(respSize + 5);
 
         // add the success byte
         base_serializers.uint8(1, responseBuffer, 0);
@@ -229,13 +229,13 @@ let UdprosUtils = {
         const errorMessage = 'Unable to handle service call';
         const errLen = errorMessage.length;
         // FIXME: check that we don't need the extra 4 byte message len here
-        responseBuffer = new Buffer(5 + errLen);
+        responseBuffer = Buffer.allocUnsafe(5 + errLen);
         base_serializers.uint8(0, responseBuffer, 0);
         base_serializers.string(errorMessage, responseBuffer, 1);
       }
     }
     else {
-      responseBuffer = new Buffer(ResponseClass.getMessageSize(response));
+      responseBuffer = Buffer.allocUnsafe(ResponseClass.getMessageSize(response));
     }
 
     return responseBuffer;
@@ -246,7 +246,7 @@ let UdprosUtils = {
   },
 
   serializeString(str) {
-    const buf = new Buffer(str.length + 4);
+    const buf = Buffer.allocUnsafe(str.length + 4);
     base_serializers.string(str, buf, 0);
     return buf;
   },
@@ -267,7 +267,7 @@ let UdprosUtils = {
     let opCode = buff.readUInt8(4)
     let msgId = buff.readUInt8(5)
     let blkN = buff.readUInt16LE(6)
-    
+
     return {
       connectionId,
       opCode,
@@ -277,7 +277,7 @@ let UdprosUtils = {
   },
 
   serializeUdpHeader(connectionId, opCode, msgId, blkN){
-    const buf = new Buffer(8)
+    const buf = Buffer.allocUnsafe(8)
     base_serializers.uint32(connectionId, buf, 0)
     base_serializers.uint8(opCode, buf, 4)
     base_serializers.uint8(msgId, buf, 5)
@@ -289,5 +289,3 @@ let UdprosUtils = {
 //-----------------------------------------------------------------------
 
 module.exports = UdprosUtils;
-
-

--- a/test/Log.js
+++ b/test/Log.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const expect = chai.expect;
 const bunyan = require('bunyan');
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 const rosnodejs = require('../src/index.js');
 
 const MASTER_PORT = 11234;

--- a/test/namespaceTest.js
+++ b/test/namespaceTest.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai');
 const expect = chai.expect;
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 const names = require('../src/lib/Names.js');
 const NodeHandle = require('../src/lib/NodeHandle.js');
 const MasterStub = require('./utils/MasterStub.js');

--- a/test/onTheFly.js
+++ b/test/onTheFly.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai');
 const expect = chai.expect;
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 const rosnodejs = require('../src/index.js');
 const Master = require('./utils/MasterStub.js');
 

--- a/test/stress.js
+++ b/test/stress.js
@@ -1,6 +1,6 @@
 
 const chai = require('chai');
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 const rosnodejs = require('rosnodejs');
 
 const TOPIC = '/topic';

--- a/test/utils/MasterStub.js
+++ b/test/utils/MasterStub.js
@@ -1,4 +1,4 @@
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 const EventEmitter = require('events').EventEmitter;
 
 class RosMasterStub extends EventEmitter {

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const rosnodejs = require('../src/index.js');
 const Subscriber = require('../src/lib/Subscriber.js');
 const SubscriberImpl = require('../src/lib/impl/SubscriberImpl.js');
-const xmlrpc = require('xmlrpc');
+const xmlrpc = require('xmlrpc-rosnodejs');
 const netUtils = require('../src/utils/network_utils.js');
 const MasterStub = require('./utils/MasterStub.js');
 


### PR DESCRIPTION
This PR addresses one issue and one warning and adds two (minor) features:

- Issue: The strict topic type checking doesn't work with the `/tf` topic which is sometimes `tf/tfMessage` (gazebo) and sometimes `tf2_msgs/TFMessage` (seemingly everywhere else). The md5 is still the same though because the definition of these two types is actually the same. Apparently other ROS tools are not bothered by this mix-and-match of types on the same topic, so I think it's OK to omit the topic type check.

- Warning: Addressed this warning we were getting when starting:
  > (node:21200) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
  
  Mostly using Buffer.allocUnsafe now, since we'll fill these buffers anyways, which might also be slightly faster.

- Features: provide the subscriber callback also with the message size in bytes as well as the publishers nodeUri. This is backwards compatible, since they are just additional arguments to the callback, i.e., will be ignored by current code. This information is useful mostly for informational purposes but also for filtering (selective listening). I use this in [ros-blessed](https://www.npmjs.com/package/ros-blessed).

-----
**Update**

Now also addresses https://github.com/RethinkRobotics-opensource/rosnodejs/issues/127 by using a newly published, separate npm package (https://www.npmjs.com/package/xmlrpc-rosnodejs) instead of depending on the github repo, as suggested in the ticket.