### PR TITLE
Adds new function getServiceType to NodeHandle: looks up type from server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha --exit test/directory.js",
     "gennodejsTest": "mocha test/gennodejsTest.js test/onTheFlyMessages.js",
     "stressTest": "mocha test/stress.js",
+    "serviceTest": "mocha --exit test/services.js",
     "flatten": "node tools/flatten.js",
     "generate": "node dist/tools/generateMessages.js",
     "compile": "babel src/ -d dist/",

--- a/src/lib/NodeHandle.js
+++ b/src/lib/NodeHandle.js
@@ -331,6 +331,10 @@ class NodeHandle {
     return this._node.getMasterUri();
   }
 
+  getServiceHeader(serviceName) {
+    return this._node.getServiceHeader(serviceName);
+  }
+
   /**
    * @typedef {Object} TopicList
    * @property {{name: string, type: string}[]} topics Array of topics

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -299,6 +299,41 @@ class RosNode extends EventEmitter {
     return this._masterApi.getSystemState(this._nodeName, options);
   }
 
+  /** Services currently do not declare their type with the master, so instead
+    we probe the service for its headers. Just like in
+  https://github.com/ros/ros_comm/blob/6292d54dc14395531bffb2e165f3954fb0ef2c34/tools/rosservice/src/rosservice/__init__.py#L94-L98
+  */
+  getServiceHeader(serviceName) {
+    return new Promise((resolve, reject) => {
+
+      this.lookupService(serviceName).then((resp) => {
+        const serviceUri = resp[2];
+        const serviceHost = NetworkUtils.getAddressAndPortFromUri(serviceUri);
+
+        const client = net.connect(serviceHost, () => {
+          const serviceClientHeader = tcprosUtils.createServiceClientHeader(
+            this._nodeName, serviceName, '*', '*', false);
+
+          let deserializer = new DeserializeStream();
+          client.$deserializeStream = deserializer;
+          client.pipe(deserializer);
+
+          deserializer.once('message', (msg) => {
+            const header = tcprosUtils.parseTcpRosHeader(msg);
+            resolve(header);
+          });
+
+          client.on('error', (err) => {
+            this._log.warn(`Service Client ${this.getService()} error: ${err}`);
+            reject(err);
+          });
+
+          client.write(serviceClientHeader);
+        });
+      }).catch(reject);
+    });
+  }
+
   /**
    * Delays xmlrpc calls until our servers are set up
    * Since we need their ports for most of our calls.

--- a/test/directory.js
+++ b/test/directory.js
@@ -5,3 +5,4 @@ require('./xmlrpcTest.js');
 require('./Log.js');
 require('./onTheFly.js');
 require('./messages.js');
+require('./services.js');

--- a/test/services.js
+++ b/test/services.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const chai = require('chai');
+const expect = chai.expect;
+const { spawn } = require('child_process');
+
+const rosnodejs = require('../src/index.js');
+
+const MASTER_PORT = 11235;
+
+const initArgs = {
+  rosMasterUri: `http://localhost:${MASTER_PORT}`,
+  logging: {skipRosLogging: true},
+  notime: true
+};
+
+describe('Services Tests', () => {
+
+  let rn;
+  let core;
+
+  before((done) => {
+    // start a ros master
+    core = spawn('roscore', ['-p', MASTER_PORT]);
+    setTimeout(() => rosnodejs.initNode('/testNode', initArgs).then((rn_) => {
+        rn = rn_;
+        done();
+      }), 1000); // allow 1s for ros master to start
+  });
+
+  after((done) => {
+    rosnodejs.shutdown().then(() => {
+      rosnodejs.reset();
+      core && core.kill('SIGINT');
+      done();
+    });
+  });
+
+  describe('get type', () => {
+    it('can get the type', async function() {
+      const p = await rn.getServiceHeader('/rosout/get_loggers');
+      expect(p.type).to.equal('roscpp/GetLoggers');
+    });
+  });
+});


### PR DESCRIPTION
As explained in [ros_comm](https://github.com/ros/ros_comm/blob/6292d54dc14395531bffb2e165f3954fb0ef2c34/tools/rosservice/src/rosservice/__init__.py#L94-L98):
> Services currently do not declare their type with the master, so instead we probe the service for its headers.

The added function does just that. Test included.

Mini-example:

```lang-js
const type = await rn.getServiceHeader('/rosout/get_loggers');
console.log(type)
```

Output:
```
{
  callerid: '/rosout',
  md5sum: '32e97e85527d4678a8f9279894bb64b0',
  request_type: 'roscpp/GetLoggersRequest',
  response_type: 'roscpp/GetLoggersResponse',
  type: 'roscpp/GetLoggers'
}
```