### PR TITLE
Small test fix

### DIFF
--- a/test/services.js
+++ b/test/services.js
@@ -37,9 +37,11 @@ describe('Services Tests', () => {
   });
 
   describe('get type', () => {
-    it('can get the type', async function() {
-      const p = await rn.getServiceHeader('/rosout/get_loggers');
-      expect(p.type).to.equal('roscpp/GetLoggers');
+    it('can get the type', function(done) {
+      rn.getServiceHeader('/rosout/get_loggers').then((p) => {
+        expect(p.type).to.equal('roscpp/GetLoggers');
+        done();
+      });
     });
   });
 });

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -569,7 +569,8 @@ describe('Protocol Test', () => {
       const subImpl = new SubscriberImpl({
           topic,
           type: 'std_msgs/String',
-          typeClass: rosnodejs.require('std_msgs').msg.String
+          typeClass: rosnodejs.require('std_msgs').msg.String,
+          transports: ['TCPROS']
         },
         nh._node);
 


### PR DESCRIPTION
We now require that the options passed to `SubscriberImpl` include a transports option. Usually the `NodeHandle` takes care of this, but it was missing in one of our tests.