### PR TITLE
Fix security vulnerabilities reported by Github dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "argparse": "1.0.10",
-    "async": "2.6.1",
+    "async": "2.6.4",
     "bn.js": "^4.11.6",
     "bunyan": "1.8.12",
     "md5": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bn.js": "^4.11.6",
     "bunyan": "1.8.12",
     "md5": "2.2.1",
-    "moment": "2.22.2",
+    "moment": "2.29.2",
     "ultron": "1.1.1",
     "walker": "1.0.7",
     "xmlrpc-rosnodejs": "1.4.0"


### PR DESCRIPTION
Github Dependabot reported two high vulnerabilities with the current versions of async and moment.  

- [async CVE](https://github.com/RethinkRobotics-opensource/rosnodejs/security/dependabot/4)
- [moment  CVE](https://github.com/RethinkRobotics-opensource/rosnodejs/security/dependabot/1)