### PR TITLE
fix: Remove deprecated moment package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "bn.js": "^4.11.6",
     "bunyan": "1.8.12",
     "md5": "2.2.1",
-    "moment": "2.29.2",
     "ultron": "1.1.1",
     "walker": "1.0.7",
     "xmlrpc-rosnodejs": "1.4.0"


### PR DESCRIPTION
I got another vulnerability report regarding `moment` and while look into the package I noticed that it is deprecated. Then, I realized that it is not used at all anywhere in here. Therefore, I decided to nuke it.