### PR TITLE
Fix backticks in message definitions, throw better error on missing dependencies.

### DIFF
--- a/src/utils/messageGeneration/MessageLoader.js
+++ b/src/utils/messageGeneration/MessageLoader.js
@@ -394,6 +394,9 @@ class MessageManager {
       const depIndex = dependencyChain.indexOf(depName);
       if (depIndex === -1) {
         // this dependency is not yet in the list anywhere
+        if (!packageCache[depName]) {
+          throw Error(`Missing dependency ${depName}, required by ${packageName}`);
+        }
         const insertionIndex = this._recurseDependencyChain(dependencyChain, depName);
         if (insertionIndex > maxInsertionIndex) {
           maxInsertionIndex = insertionIndex;

--- a/src/utils/messageGeneration/MessageSpec.js
+++ b/src/utils/messageGeneration/MessageSpec.js
@@ -264,13 +264,17 @@ class RosMsgSpec {
 
     const deps = this.getFullDependencies();
     const sep = '='.repeat(80);
-    w.write(this.fileContents.trim())
+
+    // escape backticks in string
+    const sanitize = (string) => string.trim().replace(/`/g, '\\`');
+
+    w.write(sanitize(this.fileContents))
       .newline();
 
     deps.forEach((dep) => {
       w.write(sep)
         .write(`MSG: ${dep.getFullMessageName()}`)
-        .write(dep.fileContents.trim())
+        .write(sanitize(dep.fileContents))
         .newline();
     });
 


### PR DESCRIPTION
Fixes #204 -- at least for this repo.

- [Message gen: escape backticks in comments](https://github.com/RethinkRobotics-opensource/rosnodejs/commit/21c3e46d15808f29ad6b8cd2bca31c9cc9ff3e6c) 
  Until now, backticks ("`") in comments in message definitions will lead to an exception when the generated message is loaded, because the generated JS code is syntactically invalid.

- [Message generation: indicate name of missing dependencies](https://github.com/RethinkRobotics-opensource/rosnodejs/commit/9966bcabd7adf19492cfae32a92e51e8a7ba9c21) 
  Previously, if a custom message definition referred to another package that was missing, the error was not giving any clues as to where the problem occurred, i.e., which packages are involved. This change fixes that, making it much easy to debug broken dependencies.